### PR TITLE
Api documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 composer.phar
 composer.lock
 phpunit.xml
+sami.phar
+cache/
+docs/
 vendor/
 .phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ after_script:
 
 after_success:
   - bin/auto_split.sh
+  - wget http://get.sensiolabs.org/sami.phar
+  - bin/build_api.sh
 
 matrix:
   allow_failures:

--- a/bin/build_api.sh
+++ b/bin/build_api.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#Run the commands only when push on master branch
+if [ ${TRAVIS_BRANCH} = "master" ]
+then
+ if [ ${TRAVIS_PULL_REQUEST} = "false" ]
+ then
+    git clone https://${GITHUB_TOKEN}@github.com/phootwork/phootwork.github.io docs
+    php sami.phar update sami.php
+    cd docs
+    git add ./
+    git commit -m"Build api documentation via Travis build nr. ${TRAVIS_BUILD_NUMBER}"
+    git push origin master
+ fi
+fi

--- a/sami.php
+++ b/sami.php
@@ -1,0 +1,25 @@
+<?php
+
+use Sami\Parser\Filter\PublicFilter;
+use Symfony\Component\Finder\Finder;
+use Sami\Sami;
+
+$iterator = Finder::create()->files()->name('*.php')->in(__DIR__ . '/src');
+
+$sami = new Sami($iterator, [
+	'title' => 'Phootwork API documentation',
+	'theme' => 'default',
+	'build_dir' => __DIR__ . '/docs/api',
+	'default_opened_level' => 2,
+	'sort_class_properties' => true,
+	'sort_class_methods' => true,
+	'sort_class_constants' => true,
+	'sort_class_traits' => true,
+	'sort_class_interfaces' => true
+]);
+
+$sami['filter'] = function () {
+	return new PublicFilter();
+};
+
+return $sami;


### PR DESCRIPTION
Even if Sami is not maintained anymore, imho it's still the best api doc generator in PHP world.
I've used the original configuration of the collection package.

I've created a script `bin/build_api.sh` and configure Travis to run it, to automatic generate the api and push it to the documentation repository, into the `phootwork.github.io/api` directory.

See also https://github.com/phootwork/phootwork.github.io/issues/4  