### PR TITLE
Integrate php-cs-fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cache/
 docs/
 vendor/
 .phpunit.result.cache
+.php_cs.cache

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,13 @@
+<?php
+
+$config = new phootwork\fixer\Config();
+$config->getFinder()
+    ->exclude(['fixture'])
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/tests')
+
+$cacheDir = getenv('TRAVIS') ? getenv('HOME') . '/.php-cs-fixer' : __DIR__;
+
+$config->setCacheFile($cacheDir . '/.php_cs.cache');
+
+return $config;

--- a/composer.json
+++ b/composer.json
@@ -1,24 +1,35 @@
 {
-  "name" : "phootwork/phootwork",
-  "type" : "library",
-  "description" : "The phootwork library fills gaps in the php language and provides better solutions than the existing ones php offers.",
-  "authors" : [{
-    "name" : "Thomas Gossmann",
-    "homepage" : "http://gos.si"
-  }
+  "name": "phootwork/phootwork",
+  "type": "library",
+  "description": "The phootwork library fills gaps in the php language and provides better solutions than the existing ones php offers.",
+  "authors": [
+    {
+      "name": "Thomas Gossmann",
+      "homepage": "http://gos.si"
+    }
   ],
-  "license" : "MIT",
-  "keywords" : ["Text object", "Array object", "collection", "collections", "list", "set", "map", "queue", "stack",
-    "xml", "json"
+  "license": "MIT",
+  "keywords": [
+    "Text object",
+    "Array object",
+    "collection",
+    "collections",
+    "list",
+    "set",
+    "map",
+    "queue",
+    "stack",
+    "xml",
+    "json"
   ],
-  "support" : {
-    "issues" : "https://github.com/phootwork/phootwork/issues"
+  "support": {
+    "issues": "https://github.com/phootwork/phootwork/issues"
   },
   "require": {
     "php": ">=7.2",
     "ext-json": "*",
-    "symfony/polyfill-mbstring" : "^1.8",
-    "ext-xml": "*"
+    "ext-xml": "*",
+    "symfony/polyfill-mbstring": "^1.8"
   },
   "replace": {
     "phootwork/collection": "self.version",
@@ -29,7 +40,8 @@
     "phootwork/xml": "self.version"
   },
   "require-dev": {
-    "phpunit/phpunit" : "^8.0",
+    "phootwork/php-cs-fixer-config": "~0.1",
+    "phpunit/phpunit": "^8.0",
     "mikey179/vfsstream": "^1.6",
     "vimeo/psalm": "^3.4"
   },
@@ -47,5 +59,10 @@
       "phootwork\\tokenizer\\tests\\": "tests/tokenizer/",
       "phootwork\\xml\\tests\\": "tests/xml/"
     }
+  },
+  "scripts": {
+    "check": "@cs",
+    "cs": "php-cs-fixer fix -v --diff --dry-run",
+    "cs-fix": "php-cs-fixer fix -v --diff"
   }
 }


### PR DESCRIPTION
This PR integrates `phootwork/php-cs-fixer-config`. Ref #11

I moved my personal project over to phootwork and republished it under the new name. That said, you should head over to [phootwork/php-cs-fixer-config](https://github.com/phootwork/php-cs-fixer-config) to add further adjustments.