### PR TITLE
Fix deploy scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ after_script:
 
 after_success:
   - bin/auto_split.sh
-  - wget http://get.sensiolabs.org/sami.phar
   - bin/build_api.sh
 
 matrix:

--- a/bin/auto_split.sh
+++ b/bin/auto_split.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
 
-#Run the commands only when push on master branch
-if [ ${TRAVIS_BRANCH} = "master" ]
+# Run the script only in the Travis job,
+# corresponding to the minumim php version supported
+if [ ${TRAVIS_PHP_VERSION} = "7.2" ]
 then
- if [ ${TRAVIS_PULL_REQUEST} = "false" ]
- then
-    git clone https://github.com/shopsys/monorepo-tools
-    git remote add dep_collection https://${GITHUB_TOKEN}@github.com/phootwork/collection
-    git remote add dep_file https://${GITHUB_TOKEN}@github.com/phootwork/file
-    git remote add dep_json https://${GITHUB_TOKEN}@github.com/phootwork/json
-    git remote add dep_lang https://${GITHUB_TOKEN}@github.com/phootwork/lang
-    git remote add dep_tokenizer https://${GITHUB_TOKEN}@github.com/phootwork/tokenizer
-    git remote add dep_xml https://${GITHUB_TOKEN}@github.com/phootwork/xml
-    monorepo-tools/monorepo_split.sh dep_collection:src/collection dep_file:src/file dep_json:src/json dep_lang:src/lang dep_tokenizer:src/tokenizer dep_xml:src/xml
- fi
+  # Run the commands only when push on master branch
+  if [ ${TRAVIS_BRANCH} = "master" ]
+  then
+    if [ ${TRAVIS_PULL_REQUEST} = "false" ]
+    then
+      git clone https://github.com/shopsys/monorepo-tools
+      git remote add dep_collection https://${GITHUB_TOKEN}@github.com/phootwork/collection
+      git remote add dep_file https://${GITHUB_TOKEN}@github.com/phootwork/file
+      git remote add dep_json https://${GITHUB_TOKEN}@github.com/phootwork/json
+      git remote add dep_lang https://${GITHUB_TOKEN}@github.com/phootwork/lang
+      git remote add dep_tokenizer https://${GITHUB_TOKEN}@github.com/phootwork/tokenizer
+      git remote add dep_xml https://${GITHUB_TOKEN}@github.com/phootwork/xml
+      monorepo-tools/monorepo_split.sh dep_collection:src/collection dep_file:src/file dep_json:src/json dep_lang:src/lang dep_tokenizer:src/tokenizer dep_xml:src/xml
+    fi
+  fi
 fi

--- a/bin/build_api.sh
+++ b/bin/build_api.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
 
-#Run the commands only when push on master branch
-if [ ${TRAVIS_BRANCH} = "master" ]
+# Run the script only in the Travis job,
+# corresponding to the minumim php version supported
+if [ ${TRAVIS_PHP_VERSION} = "7.2" ]
 then
- if [ ${TRAVIS_PULL_REQUEST} = "false" ]
- then
-    git clone https://${GITHUB_TOKEN}@github.com/phootwork/phootwork.github.io docs
-    php sami.phar update sami.php
-    cd docs
-    git add ./
-    git commit -m"Build api documentation via Travis build nr. ${TRAVIS_BUILD_NUMBER}"
-    git push origin master
- fi
+  # Run the commands only when push on master branch
+  if [ ${TRAVIS_BRANCH} = "master" ]
+  then
+    if [ ${TRAVIS_PULL_REQUEST} = "false" ]
+    then
+      wget http://get.sensiolabs.org/sami.phar
+      git clone https://${GITHUB_TOKEN}@github.com/phootwork/phootwork.github.io docs
+      php sami.phar update sami.php
+      cd docs || exit
+      git add ./
+      git commit -m"Build api documentation via Travis build nr. ${TRAVIS_BUILD_NUMBER}"
+      git push origin master
+    fi
+  fi
 fi


### PR DESCRIPTION
Adjust `bin/auto_split.sh`, `bin/build_api.sh` and `.travis.yml` to run the scripts only in one Travis job, to avoid simultaneous pushes on Github libraries repositories.

While running `bin/auto_split.sh`, if two Travis jobs of our matrix try to push to the same repository, Github rejects both pushes and the splitted library can't be updated. No problem: we can do it later by hand but why we should? We've done the automatic script for this job! With this commit, we force Travis to run the scripts only at the end of the job, corresponding to the minimum php version supported, avoiding the possibility of contemporary  pushes.