### PR TITLE
Remove duplications

### DIFF
--- a/src/collection/AbstractCollection.php
+++ b/src/collection/AbstractCollection.php
@@ -10,329 +10,54 @@
 
 namespace phootwork\collection;
 
-use \Iterator;
-use phootwork\lang\Comparator;
+use phootwork\lang\AbstractArray;
 
 /**
  * AbstractCollection providing implementation for the Collection interface.
  *
  * @author Thomas Gossmann
  */
-abstract class AbstractCollection implements Collection {
-
-	/** @var array */
-	protected $collection = [];
-
-	/**
-	 * AbstractCollection constructor.
-	 *
-	 * @param array|Iterator $collection
-	 */
-	abstract public function __construct($collection = []);
-
-	/**
-	 * Check if the collection contains the given element.
-	 *
-	 * @param mixed $element
-	 *
-	 * @return bool
-	 */
-	public function contains($element): bool {
-		return in_array($element, $this->collection, true);
-	}
-
-	/**
-	 * Return the size of the collection.
-	 *
-	 * @return int
-	 */
-	public function size(): int {
-		return count($this->collection);
-	}
-
-	/**
-	 * Check if the collection contains any element.
-	 * Return true if the collection is empty.
-	 *
-	 * @return bool
-	 */
-	public function isEmpty(): bool {
-		return count($this->collection) == 0;
-	}
+abstract class AbstractCollection extends AbstractArray implements Collection {
 
 	/**
 	 * Remove all elements from the collection.
 	 */
 	public function clear(): void {
-		$this->collection = [];
-	}
-
-	/**
-	 * Return an array containing all elements of the collection.
-	 *
-	 * @return array
-	 */
-	public function toArray(): array {
-		return $this->collection;
-	}
-
-	/**
-	 * Applies the callback to the elements
-	 *
-	 * @param callable $callback the applied callback function
-	 * @return static
-	 */
-	public function map(callable $callback): self {
-		return new static(array_map($callback, $this->collection));
-	}
-
-	/**
-	 * Filters elements using a callback function
-	 *
-	 * @param callable $callback the filter function
-	 * @return static
-	 */
-	public function filter(callable $callback): self {
-		return new static(array_filter($this->collection, $callback));
-	}
-
-	/**
-	 * Tests whether all elements in the collection pass the test implemented by the provided function.
-	 *
-	 * Returns <code>false</code> if an error occurs otherwise returns <code>true</code>.
-	 * Returns <code>true</code> for an empty collection, too.
-	 *
-	 * @param callable $callback
-	 * @return boolean
-	 */
-	public function every(callable $callback): bool {
-		$match = true;
-		foreach ($this->collection as $element) {
-			$match = $match && $callback($element);
-		}
-
-		return $match;
-	}
-
-	/**
-	 * Tests whether at least one element in the collection passes the test implemented by the provided function.
-	 *
-	 * Returns <code>false</code> for an empty collection.
-	 *
-	 * @param callable $callback
-	 * @return boolean
-	 */
-	public function some(callable $callback): bool {
-		$match = false;
-		foreach ($this->collection as $element) {
-			$match = $match || $callback($element);
-		}
-
-		return $match;
-	}
-
-	/**
-	 * Searches the collection for query using the callback function on each element
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query (optional)
-	 * @param callable $callback
-	 *
-	 * @return boolean
-	 */
-	public function search(): bool {
-		if (func_num_args() == 1) {
-			$callback = func_get_arg(0);
-		} else {
-			$query = func_get_arg(0);
-			$callback = func_get_arg(1);
-		}
-
-		foreach ($this->collection as $element) {
-			$return = func_num_args() == 1 ? $callback($element) : $callback($element, $query);
-
-			if ($return) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Searches the collection with a given callback and returns the first element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 *
-	 * @return mixed|null the found element or null if it hasn't been found
-	 */
-	public function find() {
-		if (func_num_args() == 1) {
-			$callback = func_get_arg(0);
-		} else {
-			$query = func_get_arg(0);
-			$callback = func_get_arg(1);
-		}
-
-		foreach ($this->collection as $element) {
-			$return = func_num_args() == 1 ? $callback($element) : $callback($element, $query);
-
-			if ($return) {
-				return $element;
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Searches the collection with a given callback and returns the last element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 *
-	 * @return mixed|null the found element or null if it hasn't been found
-	 */
-	public function findLast() {
-		if (func_num_args() == 1) {
-			$callback = func_get_arg(0);
-		} else {
-			$query = func_get_arg(0);
-			$callback = func_get_arg(1);
-		}
-
-		$reverse = array_reverse($this->collection, true);
-		foreach ($reverse as $element) {
-			$return = func_num_args() == 1 ? $callback($element) : $callback($element, $query);
-
-			if ($return) {
-				return $element;
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Searches the collection with a given callback and returns all matching elements.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 *
-	 * @return null|self the found element or null if it hasn't been found
-	 */
-	public function findAll(): ?self {
-		if (func_num_args() == 1) {
-			$callback = func_get_arg(0);
-		} else {
-			$query = func_get_arg(0);
-			$callback = func_get_arg(1);
-		}
-
-		$collection = [];
-		foreach ($this->collection as $k => $element) {
-			$return = func_num_args() == 1 ? $callback($element) : $callback($element, $query);
-
-			if ($return) {
-				$collection[$k] = $element;
-			}
-		}
-
-		return new static($collection);
-	}
-
-	/**
-	 * Internal sort function
-	 *
-	 * @param array $collection the collection on which is operated on
-	 * @param Comparator|callable|null $cmp the compare function
-	 * @param callable $usort the sort function for user passed $cmd
-	 * @param callable $sort the default sort function
-	 *
- 	 * @internal
-	 */
-	protected function doSort(&$collection, $cmp, callable $usort, callable $sort): void {
-		if (is_callable($cmp)) {
-			$usort($collection, $cmp);
-		} else if ($cmp instanceof Comparator) {
-			$usort(
-				$collection,
-				/**
-				 * @param mixed $a
-				 * @param mixed $b
-				 * @return int
-				 */
-				function($a, $b) use ($cmp): int {
-					return $cmp->compare($a, $b);
-				}
-			);
-		} else {
-			$sort($collection);
-		}
+		$this->array = [];
 	}
 
 	/**
 	 * @internal
 	 */
 	public function rewind() {
-		return reset($this->collection);
+		return reset($this->array);
 	}
 
 	/**
 	 * @internal
 	 */
 	public function current() {
-		return current($this->collection);
+		return current($this->array);
 	}
 
 	/**
 	 * @internal
 	 */
 	public function key(): int {
-		return key($this->collection);
+		return key($this->array);
 	}
 
 	/**
 	 * @internal
 	 */
 	public function next() {
-		return next($this->collection);
+		return next($this->array);
 	}
 
 	/**
 	 * @internal
 	 */
 	public function valid(): bool {
-		return key($this->collection) !== null;
-	}
-
-	/**
-	 * @internal
-	 */
-	public function __clone() {
-		return new static($this->collection);
+		return key($this->array) !== null;
 	}
 }

--- a/src/collection/AbstractList.php
+++ b/src/collection/AbstractList.php
@@ -11,47 +11,21 @@
 namespace phootwork\collection;
 
 use phootwork\lang\Comparator;
+use phootwork\lang\parts\EachPart;
+use phootwork\lang\parts\IndexFindersPart;
+use phootwork\lang\parts\ReducePart;
+use phootwork\lang\parts\RemovePart;
+use phootwork\lang\parts\ReversePart;
 
 /**
  * Abstract class for all list-like collections
  *
  * @author Thomas Gossmann
+ * @author Cristiano Cinotti
  */
 abstract class AbstractList extends AbstractCollection {
-	/**
-	 * Iterative reduction of this collection with the help of a callback function. The callback
-	 * function takes two parameters, the first is the carry, the second the current item, with this
-	 * signature: mixed callback(mixed $carry, mixed $item)
-	 *
-	 * @param callable $callback the callback function
-	 * @param mixed $fallback the default value, that will be returned when the list is empty
-	 * @return mixed
-	 */
-	public function reduce(callable $callback, $fallback = null) {
-		return array_reduce($this->collection, $callback, $fallback);
-	}
 
-	/**
-	 * Sorts the collection.
-	 * 
-	 * @param Comparator|callable $cmp
-	 * @return $this
-	 */
-	public function sort($cmp = null): self {
-		$this->doSort($this->collection, $cmp, 'usort', 'sort');
-
-		return $this;
-	}
-
-	/**
-	 * Reverses the order of all elements
-	 * 
-	 * @return $this
-	 */
-	public function reverse(): self {
-		$this->collection = array_reverse($this->collection);
-		return $this;
-	}
+	use EachPart, IndexFindersPart, ReducePart, RemovePart, ReversePart;
 
 	/**
 	 * Sorts the collection in reverse order
@@ -63,16 +37,5 @@ abstract class AbstractList extends AbstractCollection {
 	 */
 	public function reverseSort($cmp = null): self {
 		return $this->sort($cmp)->reverse();
-	}
-	
-	/**
-	 * Iterates the collection and calls the callback function with the current item as parameter
-	 * 
-	 * @param callable $callback
-	 */
-	public function each(callable $callback): void {
-		foreach ($this->collection as $item) {
-			$callback($item);
-		}
 	}
 }

--- a/src/collection/ArrayList.php
+++ b/src/collection/ArrayList.php
@@ -11,6 +11,9 @@
 namespace phootwork\collection;
 
 use \Iterator;
+use phootwork\lang\parts\AccessorsPart;
+use phootwork\lang\parts\AddAllPart;
+use phootwork\lang\parts\AddPart;
 
 /**
  * Represents a List
@@ -18,7 +21,9 @@ use \Iterator;
  * @author Thomas Gossmann
  */
 class ArrayList extends AbstractList {
-	
+
+	use AccessorsPart, AddPart, AddAllPart;
+
 	/**
 	 * Creates a new ArrayList
 	 * 
@@ -26,77 +31,6 @@ class ArrayList extends AbstractList {
 	 */
 	public function __construct($collection = []) {
 		$this->addAll($collection);
-	}
-	
-	/**
-	 * Adds an element to that list
-	 * 
-	 * @param mixed $element
-	 * @param int $index
-	 * @return $this
-	 */
-	public function add($element, int $index = null): self {
-		if ($index === null) {
-			$this->collection[$this->size()] = $element;
-		} else {
-			array_splice($this->collection, $index, 0, $element);
-		}
-		
-		return $this;
-	}
-	
-	/**
-	 * Adds all elements to the list
-	 * 
-	 * @param array|Iterator $collection
-	 * @return $this
-	 */
-	public function addAll($collection): self {
-		foreach ($collection as $element) {
-			$this->add($element);
-		}
-		
-		return $this;
-	}
-
-	/**
-	 * Returns the element at the given index (or null if the index isn't present)
-	 * 
-	 * @param int $index
-	 * @return mixed
-	 */
-	public function get(int $index) {
-		if (isset($this->collection[$index])) {
-			return $this->collection[$index];
-		}
-
-		return null;
-	}
-
-	/**
-	 * Returns the index of the given element or null if the element can't be found
-	 * 
-	 * @param mixed $element
-	 * @return int the index for the given element
-	 */
-	public function indexOf($element): ?int {
-		$output = array_search($element, $this->collection, true);
-
-		return false === $output ? null : $output;
-	}
-	
-	/**
-	 * Removes an element from the list
-	 * 
-	 * @param mixed $element
-	 * @return $this
-	 */
-	public function remove($element): self {
-		if (null !== $index = $this->indexOf($element)) {
-			$this->removeByIndex($index);
-		}
-
-		return $this;
 	}
 
 	/**
@@ -106,78 +40,10 @@ class ArrayList extends AbstractList {
 	 * @return ArrayList
 	 */
 	public function removeByIndex(int $index): self {
-		if (isset($this->collection[$index])) {
-			unset($this->collection[$index]);
+		if (isset($this->array[$index])) {
+			unset($this->array[$index]);
 		}
 
 		return $this;
-	}
-
-	/**
-	 * Removes all elements from the list
-	 *
-	 * @param array|Iterator $collection
-	 * @return $this
-	 */
-	public function removeAll($collection): self {
-		foreach ($collection as $element) {
-			$this->remove($element);
-		}
-		
-		return $this;
-	}
-
-	/**
-	 * Searches the collection with a given callback and returns the index for the first element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 * @return int|null the index or null if it hasn't been found
-	 */
-	public function findIndex(): ?int {
-		if (func_num_args() == 1) {
-			$index = $this->find(func_get_arg(0));
-		} else {
-			$index = $this->find(func_get_arg(0), func_get_arg(1));
-		}
-
-		if ($index !== null) {
-			$index = $this->indexOf($index);
-		}
-
-		return $index;
-	}
-
-	/**
-	 * Searches the collection with a given callback and returns the index for the last element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 * @return int|null the index or null if it hasn't been found
-	 */
-	public function findLastIndex(): ?int {
-		if (func_num_args() == 1) {
-			$index = $this->findLast(func_get_arg(0));
-		} else {
-			$index = $this->findLast(func_get_arg(0), func_get_arg(1));
-		}
-
-		if ($index !== null) {
-			$index = $this->indexOf($index);
-		}
-
-		return $index;
 	}
 }

--- a/src/collection/Map.php
+++ b/src/collection/Map.php
@@ -11,7 +11,9 @@
 namespace phootwork\collection;
 
 use \Iterator;
+use phootwork\lang\AbstractArray;
 use phootwork\lang\Comparator;
+use phootwork\lang\parts\SortAssocPart;
 use phootwork\lang\Text;
 
 /**
@@ -20,6 +22,8 @@ use phootwork\lang\Text;
  * @author Thomas Gossmann
  */
 class Map extends AbstractCollection implements \ArrayAccess {
+
+	use SortAssocPart;
 	
 	/**
 	 * Creates a new Map
@@ -51,7 +55,7 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 */
 	public function set($key, $element): self {
 		$key = $this->extractKey($key);
-		$this->collection[$key] = $element;
+		$this->array[$key] = $element;
 		
 		return $this;
 	}
@@ -65,8 +69,8 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 */
 	public function get($key, $default = null) {
 		$key = $this->extractKey($key);
-		if (isset($this->collection[$key])) {
-			return $this->collection[$key];
+		if (isset($this->array[$key])) {
+			return $this->array[$key];
 		} else {
 			return $default;
 		}
@@ -79,7 +83,7 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 * @return mixed
 	 */
 	public function getKey($value) {
-		foreach ($this->collection as $k => $v) {
+		foreach ($this->array as $k => $v) {
 			if ($v === $value) {
 				return $k;
 			}
@@ -111,9 +115,8 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 */
 	public function remove($key): self {
 		$key = $this->extractKey($key);
-		if (isset($this->collection[$key])) {
-			$element = $this->collection[$key];
-			unset($this->collection[$key]);
+		if (isset($this->array[$key])) {
+			unset($this->array[$key]);
 		}
 
 		return $this;
@@ -125,7 +128,7 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 * @return Set the map's keys
 	 */
 	public function keys(): Set {
-		return new Set(array_keys($this->collection));
+		return new Set(array_keys($this->array));
 	}
 	
 	/**
@@ -134,7 +137,7 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 * @return ArrayList the map's values
 	 */
 	public function values(): ArrayList {
-		return new ArrayList(array_values($this->collection));
+		return new ArrayList(array_values($this->array));
 	}
 
 	/**
@@ -145,7 +148,7 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 */
 	public function has($key): bool {
 		$key = $this->extractKey($key);
-		return isset($this->collection[$key]);
+		return isset($this->array[$key]);
 	}
 	
 	/**
@@ -154,35 +157,21 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 * @param Comparator|callable $cmp
 	 * @return $this
 	 */
-	public function sort($cmp = null): self {
-		$this->doSort($this->collection, $cmp, 'uasort', 'asort');
-	
-		return $this;
+	public function sort($cmp = null): AbstractArray {
+		return $this->sortAssoc($cmp);
 	}
-	
-	/**
-	 * Sorts the map by keys
-	 *
-	 * @param Comparator|callable $cmp
-	 * @return $this
-	 */
-	public function sortKeys($cmp = null): self {
-		$this->doSort($this->collection, $cmp, 'uksort', 'ksort');
-	
-		return $this;
-	}
-	
+
 	/**
 	 * Iterates the map and calls the callback function with the current key and value as parameters
 	 *
 	 * @param callable $callback
 	 */
 	public function each(callable $callback): void {
-		foreach ($this->collection as $key => $value) {
+		foreach ($this->array as $key => $value) {
 			$callback($key, $value);
 		}
 	}
-	
+
 	/**
 	 * Searches the collection with a given callback and returns the key for the first element if found.
 	 *
@@ -191,25 +180,20 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 *     function ($element [, $query]) {}
 	 *
 	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
 	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
+	 *     - find($query, callback)
+	 *     - find(callback)
+	 *
+	 * @param array $arguments
 	 * @return mixed|null the key or null if it hasn't been found
 	 */
-	public function findKey() {
-		if (func_num_args() == 1) {
-			$index = $this->find(func_get_arg(0));
-		} else {
-			$index = $this->find(func_get_arg(0), func_get_arg(1));
-		}
-		
-		if ($index !== null) {
-			$index = $this->getKey($index);
-		}
-	
-		return $index;
+	public function findKey(...$arguments) {
+		$index = count($arguments) === 1 ? $this->find($arguments[0]) : $this->find($arguments[0], $arguments[1]);
+
+		return $this->getKey($index);
 	}
-	
+
 	/**
 	 * Searches the collection with a given callback and returns the key for the last element if found.
 	 *
@@ -218,23 +202,18 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 *     function ($element [, $query]) {}
 	 *
 	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
 	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
+	 *     - find($query, callback)
+	 *     - find(callback)
+	 *
+	 * @param array $arguments
 	 * @return mixed|null the key or null if it hasn't been found
 	 */
-	public function findLastKey() {
-		if (func_num_args() == 1) {
-			$index = $this->findLast(func_get_arg(0));
-		} else {
-			$index = $this->findLast(func_get_arg(0), func_get_arg(1));
-		}
+	public function findLastKey(...$arguments) {
+		$index = count($arguments) === 1 ? $this->findLast($arguments[0]) : $this->findLast($arguments[0], $arguments[1]);
 
-		if ($index !== null) {
-			$index = $this->getKey($index);
-		}
-	
-		return $index;
+		return $this->getKey($index);
 	}
 
 	/**
@@ -242,7 +221,7 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 */
 	public function offsetSet($offset, $value) {
 		if (!is_null($offset)) {
-			$this->collection[$offset] = $value;
+			$this->array[$offset] = $value;
 		}
 	}
 	
@@ -250,20 +229,20 @@ class Map extends AbstractCollection implements \ArrayAccess {
 	 * @internal
 	 */
 	public function offsetExists($offset) {
-		return isset($this->collection[$offset]);
+		return isset($this->array[$offset]);
 	}
 	
 	/**
 	 * @internal
 	 */
 	public function offsetUnset($offset) {
-		unset($this->collection[$offset]);
+		unset($this->array[$offset]);
 	}
 	
 	/**
 	 * @internal
 	 */
 	public function offsetGet($offset) {
-		return isset($this->collection[$offset]) ? $this->collection[$offset] : null;
+		return isset($this->array[$offset]) ? $this->array[$offset] : null;
 	}
 }

--- a/src/collection/Queue.php
+++ b/src/collection/Queue.php
@@ -28,7 +28,7 @@ class Queue extends AbstractList {
 	 */
 	public function __construct($collection = []) {
 		foreach ($collection as $element) {
-			$this->collection[] = $element;
+			$this->array[] = $element;
 		}
 	}
 	
@@ -39,7 +39,7 @@ class Queue extends AbstractList {
 	 * @return $this
 	 */
 	public function enqueue($element): self {
-		array_unshift($this->collection, $element);
+		array_unshift($this->array, $element);
 		
 		return $this;
 	}
@@ -65,7 +65,7 @@ class Queue extends AbstractList {
 	 */
 	public function peek() {
 		if ($this->size() > 0) {
-			return $this->collection[0];
+			return $this->array[0];
 		}
 		
 		return null;
@@ -77,6 +77,6 @@ class Queue extends AbstractList {
 	 * @return mixed
 	 */
 	public function poll() {
-		return array_shift($this->collection);
+		return array_shift($this->array);
 	}
 }

--- a/src/collection/Set.php
+++ b/src/collection/Set.php
@@ -11,6 +11,7 @@
 namespace phootwork\collection;
 
 use \Iterator;
+use phootwork\lang\parts\AddAllPart;
 
 /**
  * Represents a Set
@@ -18,6 +19,8 @@ use \Iterator;
  * @author Thomas Gossmann
  */
 class Set extends AbstractList {
+
+	use AddAllPart;
 
 	/**
 	 * Creates a new Set
@@ -35,52 +38,8 @@ class Set extends AbstractList {
 	 * @return $this
 	 */
 	public function add($element): self {
-		if (!in_array($element, $this->collection, true)) {
-			$this->collection[$this->size()] = $element;
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Adds all elements to the set
-	 *
-	 * @param array|Iterator $collection
-	 * @return $this
-	 */
-	public function addAll($collection): self {
-		foreach ($collection as $element) {
-			$this->add($element);
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Removes an element from the set
-	 *
-	 * @param mixed $element
-	 * @return $this
-	 */
-	public function remove($element): self {
-		$index = array_search($element, $this->collection, true);
-		if ($index !== false) {
-			unset($this->collection[$index]);
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Removes all elements from the set
-	 *
-	 * @param array|Iterator $collection
-	 *
-	 * @return $this
-	 */
-	public function removeAll($collection): self {
-		foreach ($collection as $element) {
-			$this->remove($element);
+		if (!in_array($element, $this->array, true)) {
+			$this->array[$this->size()] = $element;
 		}
 
 		return $this;

--- a/src/collection/Stack.php
+++ b/src/collection/Stack.php
@@ -11,6 +11,7 @@
 namespace phootwork\collection;
 
 use \Iterator;
+use phootwork\lang\parts\PopPart;
 
 /**
  * Represents a Stack
@@ -20,6 +21,8 @@ use \Iterator;
  * @author Thomas Gossmann
  */
 class Stack extends AbstractList {
+
+	use PopPart;
 
 	/**
 	 * Creates a new ArrayList
@@ -37,7 +40,7 @@ class Stack extends AbstractList {
 	 * @return $this
 	 */
 	public function push($element): self {
-		array_push($this->collection, $element);
+		array_push($this->array, $element);
 		
 		return $this;
 	}
@@ -63,18 +66,9 @@ class Stack extends AbstractList {
 	 */
 	public function peek() {
 		if ($this->size() > 0) {
-			return $this->collection[$this->size() - 1];
+			return $this->array[$this->size() - 1];
 		}
 
 		return null;
-	}
-	
-	/**
-	 * Pops the element at the head from the stack or null if the stack is empty
-	 * 
-	 * @return mixed
-	 */
-	public function pop() {
-		return array_pop($this->collection);
 	}
 }

--- a/src/lang/AbstractArray.php
+++ b/src/lang/AbstractArray.php
@@ -1,0 +1,284 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang;
+
+/**
+ * Superclass containing property and methods shared between
+ * `phootwork\lang\ArrayObject` and `phootwork\class\AbstractCollection`
+ *
+ * @author Cristiano Cinotti
+ */
+abstract class AbstractArray {
+
+	/** @var array */
+	protected $array = [];
+
+	abstract public function __construct(array $contents = []);
+
+	/**
+	 * Counts the array
+	 *
+	 * @return int the amount of items
+	 */
+	public function count(): int {
+		return count($this->array);
+	}
+
+	/**
+	 * Return the size of the array.
+	 * Alias of `count`
+	 *
+	 * @return int
+	 */
+	public function size(): int {
+		return $this->count();
+	}
+
+	public function __clone() {
+		return new static($this->array);
+	}
+
+	/**
+	 * Checks whether the given element is in this array
+	 *
+	 * @param mixed $element
+	 * @return boolean
+	 */
+	public function contains($element): bool {
+		return in_array($element, $this->array, true);
+	}
+
+	/**
+	 * Checks whether this array is empty
+	 *
+	 * @return boolean
+	 */
+	public function isEmpty(): bool {
+		return count($this->array) === 0;
+	}
+
+	/**
+	 * Searches the array with a given callback and returns the first element if found.
+	 *
+	 * The callback function takes one or two parameters:
+	 *
+	 *     function ($element [, $query]) {}
+	 *
+	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
+	 *
+	 *     - find($query, callback)
+	 *     - find(callback)
+	 *
+	 * @param array $arguments
+	 * @return mixed|null the found element or null if it hasn't been found
+	 */
+	public function find(...$arguments) {
+		foreach ($this->array as $element) {
+			$return = count($arguments) === 1 ? $arguments[0]($element) : $arguments[1]($element, $arguments[0]);
+
+			if ($return) {
+				return $element;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Searches the array with a given callback and returns the last element if found.
+	 *
+	 * The callback function takes one or two parameters:
+	 *
+	 *     function ($element [, $query]) {}
+	 *
+	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
+	 *
+	 *     - find($query, callback)
+	 *     - find(callback)
+	 *
+	 * @param array $arguments
+	 * @return mixed|null the found element or null if it hasn't been found
+	 */
+	public function findLast(...$arguments) {
+		$reverse = array_reverse($this->array, true);
+		foreach ($reverse as $element) {
+			$return = count($arguments) === 1 ? $arguments[0]($element) : $arguments[1]($element, $arguments[0]);
+
+			if ($return) {
+				return $element;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Searches the array with a given callback and returns all matching elements.
+	 *
+	 * The callback function takes one or two parameters:
+	 *
+	 *     function ($element [, $query]) {}
+	 *
+	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
+	 *
+	 *     - find($query, callback)
+	 *     - find(callback)
+	 *
+	 * @param array $arguments
+	 * @return mixed|null the found element or null if it hasn't been found
+	 */
+	public function findAll(...$arguments) {
+		$array = [];
+		foreach ($this->array as $k => $element) {
+			$return = count($arguments) === 1 ? $arguments[0]($element) : $arguments[1]($element, $arguments[0]);
+
+			if ($return) {
+				$array[$k] = $element;
+			}
+		}
+
+		return new static($array);
+	}
+
+	/**
+	 * Searches the array for query using the callback function on each element
+	 *
+	 * The callback function takes one or two parameters:
+	 *
+	 *     function ($element [, $query]) {}
+	 *
+	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
+	 *
+	 *     - search($query, callback)
+	 *     - search(callback)
+	 *
+	 * @param array $arguments
+	 * @return boolean
+	 */
+	public function search(...$arguments): bool {
+		foreach ($this->array as $element) {
+			$return = count($arguments) === 1 ? $arguments[0]($element) : $arguments[1]($element, $arguments[0]);
+
+			if ($return) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Returns the php array type
+	 *
+	 * @return array
+	 */
+	public function toArray(): array {
+		return $this->array;
+	}
+
+	/**
+	 * Sorts the array
+	 *
+	 * @param Comparator|callable $cmp
+	 * @return $this
+	 */
+	public function sort($cmp = null): self {
+		$this->doSort($this->array, 'usort', 'sort', $cmp);
+
+		return $this;
+	}
+
+	/**
+	 * Internal sort function
+	 *
+	 * @param array $array the array on which is operated on
+	 * @param callable $usort the sort function for user passed $cmd
+	 * @param callable $sort the default sort function
+	 * @param Comparator|callable $cmp the compare function
+	 */
+	protected function doSort(array &$array, callable $usort, callable $sort, $cmp = null): void {
+		if (is_callable($cmp)) {
+			$usort($array, $cmp);
+		} else if ($cmp instanceof Comparator) {
+			$usort(
+				$array,
+				/**
+				 * @param mixed $a
+				 * @param mixed $b
+				 * @return int
+				 */
+				function ($a, $b) use ($cmp): int {
+					return $cmp->compare($a, $b);
+				}
+			);
+		} else {
+			$sort($array);
+		}
+	}
+
+	/**
+	 * Tests whether all elements in the array pass the test implemented by the provided function.
+	 *
+	 * Returns <code>true</code> for an empty array.
+	 *
+	 * @param callable $callback
+	 * @return boolean
+	 */
+	public function every(callable $callback): bool {
+		$match = true;
+		foreach ($this->array as $element) {
+			$match = $match && $callback($element);
+		}
+
+		return $match;
+	}
+
+	/**
+	 * Tests whether at least one element in the array passes the test implemented by the provided function.
+	 *
+	 * Returns <code>false</code> for an empty array.
+	 *
+	 * @param callable $callback
+	 * @return boolean
+	 */
+	public function some(callable $callback): bool {
+		$match = false;
+		foreach ($this->array as $element) {
+			$match = $match || $callback($element);
+		}
+
+		return $match;
+	}
+
+	/**
+	 * Filters elements using a callback function
+	 *
+	 * @param callable $callback the filter function
+	 * @return static
+	 */
+	public function filter(callable $callback): self {
+		return new static(array_filter($this->array, $callback));
+	}
+
+	/**
+	 * Applies the callback to the elements
+	 *
+	 * @param callable $callback the applied callback function
+	 * @return static
+	 */
+	public function map(callable $callback): self {
+		return new static(array_map($callback, $this->array));
+	}
+}

--- a/src/lang/ArrayObject.php
+++ b/src/lang/ArrayObject.php
@@ -10,26 +10,32 @@
 
 namespace phootwork\lang;
 
-class ArrayObject implements \ArrayAccess, \Countable, \IteratorAggregate, \Serializable, Arrayable {
+use phootwork\lang\parts\AccessorsPart;
+use phootwork\lang\parts\AddAllPart;
+use phootwork\lang\parts\AddPart;
+use phootwork\lang\parts\EachPart;
+use phootwork\lang\parts\IndexFindersPart;
+use phootwork\lang\parts\PopPart;
+use phootwork\lang\parts\ReducePart;
+use phootwork\lang\parts\RemovePart;
+use phootwork\lang\parts\ReversePart;
+use phootwork\lang\parts\SortAssocPart;
 
-	/** @var array */
-	protected $array;
+class ArrayObject extends AbstractArray implements \ArrayAccess, \Countable, \IteratorAggregate, \Serializable, Arrayable {
+
+	use AccessorsPart;
+	use AddAllPart;
+	use AddPart;
+	use EachPart;
+	use IndexFindersPart;
+	use PopPart;
+	use ReducePart;
+	use RemovePart;
+	use ReversePart;
+	use SortAssocPart;
 
 	public function __construct(array $contents = []) {
 		$this->array = $contents;
-	}
-
-	public function __clone() {
-		return new ArrayObject($this->array);
-	}
-
-	/**
-	 * Counts the array
-	 *
-	 * @return int the amount of items
-	 */
-	public function count(): int {
-		return count($this->array);
 	}
 
 	public function getIterator(): \ArrayIterator {
@@ -61,15 +67,6 @@ class ArrayObject implements \ArrayAccess, \Countable, \IteratorAggregate, \Seri
 		return $this;
 	}
 
-	/**
-	 * Checks whether this array is empty
-	 *
-	 * @return boolean
-	 */
-	public function isEmpty(): bool {
-		return $this->count() === 0;
-	}
-
 	//
 	//
 	// MUTATIONS
@@ -89,46 +86,6 @@ class ArrayObject implements \ArrayAccess, \Countable, \IteratorAggregate, \Seri
 		}
 
 		return $this;
-	}
-
-	/**
-	 * Adds an element to that array
-	 *
-	 * @param mixed $element
-	 * @param int $index
-	 * @return $this
-	 */
-	public function add($element, ?int $index = null): self {
-		if ($index === null) {
-			$this->array[$this->count()] = $element;
-		} else {
-			array_splice($this->array, $index, 0, $element);
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Adds all elements to the array
-	 *
-	 * @param array|\Iterator $array
-	 * @return $this
-	 */
-	public function addAll($array): self {
-		foreach ($array as $element) {
-			$this->add($element);
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Pop the element off the end of array
-	 *
-	 * @return mixed the popped element
-	 */
-	public function pop() {
-		return array_pop($this->array);
 	}
 
 	/**
@@ -155,35 +112,6 @@ class ArrayObject implements \ArrayAccess, \Countable, \IteratorAggregate, \Seri
 	}
 
 	/**
-	 * Removes an element from the list
-	 *
-	 * @param mixed $element
-	 * @return $this
-	 */
-	public function remove($element): self {
-		$index = array_search($element, $this->array, true);
-		if ($index !== false) {
-			unset($this->array[$index]);
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Removes all elements from the list
-	 *
-	 * @param array|\Iterator $array
-	 * @return $this
-	 */
-	public function removeAll($array): self {
-		foreach ($array as $element) {
-			$this->remove($element);
-		}
-
-		return $this;
-	}
-
-	/**
 	 * Remove a portion of the array and replace it with something else
 	 *
 	 * @param int $offset If offset is positive then the start of removed portion is at that offset from the beginning of the input array. If offset is negative then it starts that far from the end of the input array.
@@ -196,345 +124,6 @@ class ArrayObject implements \ArrayAccess, \Countable, \IteratorAggregate, \Seri
 		array_splice($this->array, $offset, $length, $replacement);
 
 		return $this;
-	}
-
-	//
-	//
-	// SORTING
-	//
-	//
-
-	/**
-	 * Sorts the array
-	 *
-	 * @param Comparator|callable $cmp
-	 * @return $this
-	 */
-	public function sort($cmp = null): self {
-		$this->doSort($this->array, 'usort', 'sort', $cmp);
-
-		return $this;
-	}
-
-	/**
-	 * Sorts the array and persisting key-value pairs
-	 *
-	 * @param Comparator|callable $cmp
-	 * @return $this
-	 */
-	public function sortAssoc($cmp = null): self {
-		$this->doSort($this->array, 'uasort', 'asort', $cmp);
-
-		return $this;
-	}
-
-	/**
-	 * Sorts the array by keys
-	 *
-	 * @param Comparator|callable $cmp
-	 * @return $this
-	 */
-	public function sortKeys($cmp = null): self {
-		$this->doSort($this->array, 'uksort', 'ksort', $cmp);
-
-		return $this;
-	}
-
-	/**
-	 * Internal sort function
-	 *
-	 * @param array $array the array on which is operated on
-	 * @param callable $usort the sort function for user passed $cmd
-	 * @param callable $sort the default sort function
-	 * @param Comparator|callable $cmp the compare function
-	 */
-	protected function doSort(array &$array, callable $usort, callable $sort, $cmp = null): void {
-		if (is_callable($cmp)) {
-			$usort($array, $cmp);
-		} else if ($cmp instanceof Comparator) {
-			$usort(
-				$array,
-				/**
-				 * @param mixed $a
-				 * @param mixed $b
-				 * @return int
-				 */
-				function ($a, $b) use ($cmp): int {
-					return $cmp->compare($a, $b);
-				}
-			);
-		} else {
-			$sort($array);
-		}
-	}
-
-	/**
-	 * Reverses the order of all elements
-	 *
-	 * @return $this
-	 */
-	public function reverse(): self {
-		$this->array = array_reverse($this->array);
-		return $this;
-	}
-
-	//
-	//
-	// SEARCH
-	//
-	//
-
-	/**
-	 * Tests whether all elements in the array pass the test implemented by the provided function.
-	 *
-	 * Returns <code>true</code> for an empty array.
-	 *
-	 * @param callable $callback
-	 * @return boolean
-	 */
-	public function every(callable $callback): bool {
-		$match = true;
-		foreach ($this->array as $element) {
-			$match = $match && $callback($element);
-		}
-
-		return $match;
-	}
-
-	/**
-	 * Tests whether at least one element in the array passes the test implemented by the provided function.
-	 *
-	 * Returns <code>false</code> for an empty array.
-	 *
-	 * @param callable $callback
-	 * @return boolean
-	 */
-	public function some(callable $callback): bool {
-		$match = false;
-		foreach ($this->array as $element) {
-			$match = $match || $callback($element);
-		}
-
-		return $match;
-	}
-
-	/**
-	 * Searches the array for query using the callback function on each element
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query (optional)
-	 * @param callable $callback
-	 * @return boolean
-	 */
-	public function search(): bool {
-		if (func_num_args() == 1) {
-			$callback = func_get_arg(0);
-		} else {
-			$query = func_get_arg(0);
-			$callback = func_get_arg(1);
-		}
-
-		foreach ($this->array as $element) {
-			$return = func_num_args() == 1 ? $callback($element) : $callback($element, $query);
-
-			if ($return) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Returns the element at the given index (or null if the index isn't present)
-	 *
-	 * @param int $index
-	 * @return mixed
-	 */
-	public function get(int $index) {
-		if (isset($this->array[$index])) {
-			return $this->array[$index];
-		}
-
-		return null;
-	}
-
-	/**
-	 * Searches the array with a given callback and returns the first element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 * @return mixed|null the found element or null if it hasn't been found
-	 */
-	public function find() {
-		if (func_num_args() == 1) {
-			$callback = func_get_arg(0);
-		} else {
-			$query = func_get_arg(0);
-			$callback = func_get_arg(1);
-		}
-
-		foreach ($this->array as $element) {
-			$return = func_num_args() == 1 ? $callback($element) : $callback($element, $query);
-
-			if ($return) {
-				return $element;
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Searches the array with a given callback and returns the last element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 * @return mixed|null the found element or null if it hasn't been found
-	 */
-	public function findLast() {
-		if (func_num_args() == 1) {
-			$callback = func_get_arg(0);
-		} else {
-			$query = func_get_arg(0);
-			$callback = func_get_arg(1);
-		}
-
-		$reverse = array_reverse($this->array, true);
-		foreach ($reverse as $element) {
-			$return = func_num_args() == 1 ? $callback($element) : $callback($element, $query);
-
-			if ($return) {
-				return $element;
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Searches the array with a given callback and returns all matching elements.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 * @return mixed|null the found element or null if it hasn't been found
-	 */
-	public function findAll() {
-		if (func_num_args() == 1) {
-			$callback = func_get_arg(0);
-		} else {
-			$query = func_get_arg(0);
-			$callback = func_get_arg(1);
-		}
-
-		$array = [];
-		foreach ($this->array as $k => $element) {
-			$return = func_num_args() == 1 ? $callback($element) : $callback($element, $query);
-
-			if ($return) {
-				$array[$k] = $element;
-			}
-		}
-
-		return new static($array);
-	}
-
-	/**
-	 * Returns the index of the given element or false if the element can't be found
-	 *
-	 * @param mixed $element
-	 * @return int the index for the given element
-	 */
-	public function indexOf($element): ?int {
-		$out = array_search($element, $this->array, true);
-
-		return false === $out ? null : $out;
-	}
-
-	/**
-	 * Searches the array with a given callback and returns the index for the first element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 * @return int|null the index or null if it hasn't been found
-	 */
-	public function findIndex(): ?int {
-		if (func_num_args() == 1) {
-			$index = $this->find(func_get_arg(0));
-		} else {
-			$index = $this->find(func_get_arg(0), func_get_arg(1));
-		}
-
-		if ($index !== null) {
-			$index = $this->indexOf($index);
-		}
-
-		return $index;
-	}
-
-	/**
-	 * Searches the array with a given callback and returns the index for the last element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 *
-	 * @param mixed $query OPTIONAL the provided query
-	 * @param callable $callback the callback function
-	 * @return int|null the index or null if it hasn't been found
-	 */
-	public function findLastIndex(): ?int {
-		if (func_num_args() == 1) {
-			$index = $this->findLast(func_get_arg(0));
-		} else {
-			$index = $this->findLast(func_get_arg(0), func_get_arg(1));
-		}
-
-		if ($index !== null) {
-			$index = $this->indexOf($index);
-		}
-
-		return $index;
-	}
-
-	/**
-	 * Checks whether the given element is in this array
-	 *
-	 * @param mixed $element
-	 * @return boolean
-	 */
-	public function contains($element): bool {
-		return in_array($element, $this->array, true);
 	}
 
 	//
@@ -565,52 +154,6 @@ class ArrayObject implements \ArrayAccess, \Countable, \IteratorAggregate, \Seri
 	 */
 	public function slice(int $offset, ?int $length = null, bool $preserveKeys = false): ArrayObject {
 		return new ArrayObject(array_slice($this->array, $offset, $length, $preserveKeys));
-	}
-
-	/**
-	 * Applies the callback to the elements of the given arrays
-	 *
-	 * @param callable $callback Callback function to run for each element in each array.
-	 * @return ArrayObject
-	 */
-	public function map(callable $callback): ArrayObject {
-		return new ArrayObject(array_map($callback, $this->array));
-	}
-
-	/**
-	 * Filters elements of an array using a callback function
-	 *
-	 * @param callable $callback The callback function to use
-	 * 		If no callback is supplied, all entries of array equal to false will be removed.
-	 * @return ArrayObject
-	 */
-	public function filter(callable $callback): ArrayObject {
-		return new ArrayObject(array_filter($this->array, $callback));
-	}
-
-	/**
-	 * Iteratively reduce the array to a single value using a callback function
-	 *
-	 * @param callable $callback callback function
-	 * 		`mixed callback (mixed $carry , mixed $item)`
-	 * 		$carry - Holds the return value of the previous iteration; in the case of the first iteration it instead holds the value of initial.
-	 * 		$item - Holds the value of the current iteration.
-	 * @param mixed $initial If the optional initial is available, it will be used at the beginning of the process, or as a final result in case the array is empty.
-	 * @return mixed
-	 */
-	public function reduce(callable $callback, $initial = null) {
-		return array_reduce($this->array, $callback, $initial);
-	}
-
-	/**
-	 * Iterates the array and calls the callback function with the current item as parameter
-	 *
-	 * @param callable $callback
-	 */
-	public function each(callable $callback): void {
-		foreach ($this->array as $item) {
-			$callback($item);
-		}
 	}
 
 	/**
@@ -650,15 +193,6 @@ class ArrayObject implements \ArrayAccess, \Countable, \IteratorAggregate, \Seri
 	public function flip(): self {
 		$this->array = array_flip($this->array);
 		return $this;
-	}
-
-	/**
-	 * Returns the php array type
-	 *
-	 * @return array
-	 */
-	public function toArray(): array {
-		return $this->array;
 	}
 
 	//

--- a/src/lang/Text.php
+++ b/src/lang/Text.php
@@ -10,9 +10,9 @@
 
 namespace phootwork\lang;
 
-use phootwork\lang\text\CheckerTrait;
-use phootwork\lang\text\EnglishPluralizer;
-use phootwork\lang\text\Pluralizer;
+use phootwork\lang\parts\CheckerPart;
+use phootwork\lang\inflector\Inflector;
+use phootwork\lang\inflector\InflectorInterface;
 
 /**
  * Object representation of an immutable String
@@ -21,7 +21,7 @@ use phootwork\lang\text\Pluralizer;
  */
 class Text implements Comparable {
 
-	use CheckerTrait;
+	use CheckerPart;
 
 	/** @var string */
 	private $string;
@@ -913,11 +913,11 @@ class Text implements Comparable {
 	/**
 	 * Get the plural form of the Text object.
 	 *
-	 * @param Pluralizer|null $pluralizer
+	 * @param InflectorInterface|null $pluralizer
 	 * @return Text
 	 */
-	public function toPlural(?Pluralizer $pluralizer = null): Text {
-		$pluralizer = $pluralizer ?: new EnglishPluralizer();
+	public function toPlural(?InflectorInterface $pluralizer = null): Text {
+		$pluralizer = $pluralizer ?: new Inflector();
 
 		return new Text($pluralizer->getPluralForm($this->string), $this->encoding);
 	}
@@ -925,11 +925,11 @@ class Text implements Comparable {
 	/**
 	 * Get the singular form of the Text object.
 	 *
-	 * @param Pluralizer|null $pluralizer
+	 * @param InflectorInterface|null $pluralizer
 	 * @return Text
 	 */
-	public function toSingular(?Pluralizer $pluralizer = null): Text {
-		$pluralizer = $pluralizer ?: new EnglishPluralizer();
+	public function toSingular(?InflectorInterface $pluralizer = null): Text {
+		$pluralizer = $pluralizer ?: new Inflector();
 
 		return new Text($pluralizer->getSingularForm($this->string), $this->encoding);
 	}

--- a/src/lang/inflector/Inflector.php
+++ b/src/lang/inflector/Inflector.php
@@ -8,7 +8,7 @@
  * @copyright Thomas Gossmann
  */
 
-namespace phootwork\lang\text;
+namespace phootwork\lang\inflector;
 
 /**
  * Standard replacement English pluralizer class. Based on the links below
@@ -20,7 +20,7 @@ namespace phootwork\lang\text;
  * @author paul.hanssen
  * @author Cristiano Cinotti
  */
-class EnglishPluralizer implements Pluralizer {
+class Inflector implements InflectorInterface {
 	/**
 	 * @var array
 	 */

--- a/src/lang/inflector/InflectorInterface.php
+++ b/src/lang/inflector/InflectorInterface.php
@@ -8,7 +8,7 @@
  * @copyright Thomas Gossmann
  */
 
-namespace phootwork\lang\text;
+namespace phootwork\lang\inflector;
 
 /**
  * The generic interface to create a plural form of a name.
@@ -16,7 +16,7 @@ namespace phootwork\lang\text;
  * @author Hans Lellelid <hans@xmpl.org>
  * @author Cristiano Cinotti <cristianocinotti@gmail.com>
  */
-interface Pluralizer {
+interface InflectorInterface {
 	/**
 	 * Generate a plural name based on the passed in root.
 	 *

--- a/src/lang/parts/AccessorsPart.php
+++ b/src/lang/parts/AccessorsPart.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+trait AccessorsPart {
+
+	/**
+	 * Returns the element at the given index (or null if the index isn't present)
+	 *
+	 * @param int $index
+	 * @return mixed
+	 */
+	public function get(int $index) {
+		if (isset($this->array[$index])) {
+			return $this->array[$index];
+		}
+
+		return null;
+	}
+}

--- a/src/lang/parts/AddAllPart.php
+++ b/src/lang/parts/AddAllPart.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+trait AddAllPart {
+
+	abstract public function add($element);
+
+	/**
+	 * Adds all elements to the array
+	 *
+	 * @param array|\Iterator $array
+	 * @return $this
+	 */
+	public function addAll($array): self {
+		foreach ($array as $element) {
+			$this->add($element);
+		}
+
+		return $this;
+	}
+}

--- a/src/lang/parts/AddPart.php
+++ b/src/lang/parts/AddPart.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+trait AddPart {
+	/**
+	 * Adds an element to that array
+	 *
+	 * @param mixed $element
+	 * @param int $index
+	 * @return $this
+	 */
+	public function add($element, ?int $index = null): self {
+		if ($index === null) {
+			$this->array[count($this->array)] = $element;
+		} else {
+			array_splice($this->array, $index, 0, $element);
+		}
+
+		return $this;
+	}
+}

--- a/src/lang/parts/CheckerPart.php
+++ b/src/lang/parts/CheckerPart.php
@@ -8,9 +8,12 @@
  * @copyright Thomas Gossmann
  */
 
-namespace phootwork\lang\text;
+namespace phootwork\lang\parts;
 
-trait CheckerTrait {
+use phootwork\lang\inflector\Inflector;
+use phootwork\lang\inflector\InflectorInterface;
+
+trait CheckerPart {
 
 	/**
 	 * Checks if the string is empty
@@ -103,12 +106,12 @@ trait CheckerTrait {
 	/**
 	 * Check if a string is singular form.
 	 *
-	 * @param Pluralizer $pluralizer
-	 *        	A custom pluralizer. Default is the EnglishPluralizer
+	 * @param InflectorInterface $pluralizer
+	 *        	A custom pluralizer. Default is the Inflector
 	 * @return boolean
 	 */
-	public function isSingular(?Pluralizer $pluralizer = null): bool {
-		$pluralizer = $pluralizer ?? new EnglishPluralizer();
+	public function isSingular(?InflectorInterface $pluralizer = null): bool {
+		$pluralizer = $pluralizer ?? new Inflector();
 
 		return $pluralizer->isSingular($this->string);
 	}
@@ -116,12 +119,12 @@ trait CheckerTrait {
 	/**
 	 * Check if a string is plural form.
 	 *
-	 * @param Pluralizer $pluralizer
-	 *        	A custom pluralizer. Default is the EnglishPluralizer
+	 * @param InflectorInterface $pluralizer
+	 *        	A custom pluralizer. Default is the Inflector
 	 * @return boolean
 	 */
-	public function isPlural(?Pluralizer $pluralizer = null): bool {
-		$pluralizer = $pluralizer ?? new EnglishPluralizer();
+	public function isPlural(?InflectorInterface $pluralizer = null): bool {
+		$pluralizer = $pluralizer ?? new Inflector();
 
 		return $pluralizer->isPlural($this->string);
 	}

--- a/src/lang/parts/EachPart.php
+++ b/src/lang/parts/EachPart.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+trait EachPart {
+
+	/**
+	 * Iterates the array and calls the callback function with the current item as parameter
+	 *
+	 * @param callable $callback
+	 */
+	public function each(callable $callback): void {
+		foreach ($this->array as $item) {
+			$callback($item);
+		}
+	}
+}

--- a/src/lang/parts/IndexFindersPart.php
+++ b/src/lang/parts/IndexFindersPart.php
@@ -1,0 +1,71 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+trait IndexFindersPart {
+
+	/**
+	 * Returns the index of the given element or false if the element can't be found
+	 *
+	 * @param mixed $element
+	 * @return int the index for the given element
+	 */
+	public function indexOf($element): ?int {
+		$out = array_search($element, $this->array, true);
+
+		return false === $out ? null : $out;
+	}
+
+	/**
+	 * Searches the array with a given callback and returns the index for the last element if found.
+	 *
+	 * The callback function takes one or two parameters:
+	 *
+	 *     function ($element [, $query]) {}
+	 *
+	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
+	 *
+	 *     - find($query, callback)
+	 *     - find(callback)
+	 *
+	 * @param array $arguments
+	 * @return int|null the index or null if it hasn't been found
+	 */
+	public function findLastIndex(...$arguments): ?int {
+		$index = count($arguments) === 1 ?
+			$this->findLast($arguments[0]) : $this->findLast($arguments[0], $arguments[1]);
+
+		return $this->indexOf($index);
+	}
+
+	/**
+	 * Searches the array with a given callback and returns the index for the first element if found.
+	 *
+	 * The callback function takes one or two parameters:
+	 *
+	 *     function ($element [, $query]) {}
+	 *
+	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
+	 *
+	 *     - find($query, callback)
+	 *     - find(callback)
+	 *
+	 * @param array $arguments
+	 * @return int|null the index or null if it hasn't been found
+	 */
+	public function findIndex(...$arguments): ?int {
+		$index = count($arguments) === 1 ? $this->find($arguments[0]) : $this->find($arguments[0], $arguments[1]);
+
+		return $this->indexOf($index);
+	}
+}

--- a/src/lang/parts/PopPart.php
+++ b/src/lang/parts/PopPart.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+trait PopPart {
+	/**
+	 * Pop the element off the end of array
+	 *
+	 * @return mixed the popped element
+	 */
+	public function pop() {
+		return array_pop($this->array);
+	}
+}
+

--- a/src/lang/parts/ReducePart.php
+++ b/src/lang/parts/ReducePart.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+trait ReducePart {
+
+	/**
+	 * Iterative reduction of this array or collection with the help of a callback function. The callback
+	 * function takes two parameters, the first is the carry, the second the current item, with this
+	 * signature: mixed callback(mixed $carry, mixed $item)
+	 *
+	 * @param callable $callback the callback function
+	 * @param mixed $fallback the default value, that will be returned when the list is empty
+	 * @return mixed
+	 */
+	public function reduce(callable $callback, $fallback = null) {
+		return array_reduce($this->array, $callback, $fallback);
+	}
+}

--- a/src/lang/parts/RemovePart.php
+++ b/src/lang/parts/RemovePart.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+trait RemovePart {
+	/**
+	 * Removes an element from the array
+	 *
+	 * @param mixed $element
+	 * @return $this
+	 */
+	public function remove($element): self {
+		$index = array_search($element, $this->array, true);
+		if ($index !== false) {
+			unset($this->array[$index]);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * Removes all elements from the array
+	 *
+	 * @param array|\Iterator $array
+	 * @return $this
+	 */
+	public function removeAll($array): self {
+		foreach ($array as $element) {
+			$this->remove($element);
+		}
+
+		return $this;
+	}
+}

--- a/src/lang/parts/ReversePart.php
+++ b/src/lang/parts/ReversePart.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+trait ReversePart {
+
+	/**
+	 * Reverses the order of all elements
+	 *
+	 * @return $this
+	 */
+	public function reverse(): self {
+		$this->array = array_reverse($this->array);
+		return $this;
+	}
+}

--- a/src/lang/parts/SortAssocPart.php
+++ b/src/lang/parts/SortAssocPart.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+
+namespace phootwork\lang\parts;
+
+use phootwork\lang\Comparator;
+
+trait SortAssocPart {
+
+	/**
+	 * Sorts the array and persisting key-value pairs
+	 *
+	 * @param Comparator|callable $cmp
+	 * @return $this
+	 */
+	public function sortAssoc($cmp = null): self {
+		$this->doSort($this->array, 'uasort', 'asort', $cmp);
+
+		return $this;
+	}
+
+	/**
+	 * Sorts the array by keys
+	 *
+	 * @param Comparator|callable $cmp
+	 * @return $this
+	 */
+	public function sortKeys($cmp = null): self {
+		$this->doSort($this->array, 'uksort', 'ksort', $cmp);
+
+		return $this;
+	}
+}

--- a/tests/lang/inflector/InflectorTest.php
+++ b/tests/lang/inflector/InflectorTest.php
@@ -11,13 +11,13 @@
 namespace phootwork\lang\tests;
 
 use PHPUnit\Framework\TestCase;
-use phootwork\lang\text\EnglishPluralizer;
+use phootwork\lang\inflector\Inflector;
 
 /**
- * Tests for the StandardEnglishPluralizer class
+ * Tests for the Inflector class
  *
  */
-class EnglishPluralizerTest extends TestCase {
+class InflectorTest extends TestCase {
 	public function getPluralFormDataProvider(): array {
 		return [
 			['', 's'],
@@ -105,7 +105,7 @@ class EnglishPluralizerTest extends TestCase {
 	 * @dataProvider getPluralFormDataProvider
 	 */
 	public function testPluralForm($input, $output): void {
-		$pluralizer = new EnglishPluralizer();
+		$pluralizer = new Inflector();
 		$this->assertEquals($output, $pluralizer->getPluralForm($input));
 	}
 
@@ -115,9 +115,9 @@ class EnglishPluralizerTest extends TestCase {
 	public function testWrongTypeToPluralizeThrowsException($wrong): void {
 		$this->expectException(\TypeError::class);
 		$this->expectExceptionMessage(
-			'Argument 1 passed to phootwork\lang\text\EnglishPluralizer::getPluralForm() must be of the type string'
+			'Argument 1 passed to phootwork\lang\inflector\Inflector::getPluralForm() must be of the type string'
 		);
-		$pluralizer = new EnglishPluralizer();
+		$pluralizer = new Inflector();
 		$pluralizer->getPluralForm($wrong);
 	}
 
@@ -125,7 +125,7 @@ class EnglishPluralizerTest extends TestCase {
 	 * @dataProvider getPluralFormDataProvider
 	 */
 	public function testSingularForm($output, $input): void {
-		$pluralizer = new EnglishPluralizer();
+		$pluralizer = new Inflector();
 		$this->assertEquals($output, $pluralizer->getSingularForm($input));
 	}
 
@@ -135,15 +135,15 @@ class EnglishPluralizerTest extends TestCase {
 	public function testWrongTypeToSingularizeThrowsException($wrong): void {
 		$this->expectException(\TypeError::class);
 		$this->expectExceptionMessage(
-			'Argument 1 passed to phootwork\lang\text\EnglishPluralizer::getSingularForm() must be of the type string'
+			'Argument 1 passed to phootwork\lang\inflector\Inflector::getSingularForm() must be of the type string'
 		);
 
-		$pluralizer = new EnglishPluralizer();
+		$pluralizer = new Inflector();
 		$pluralizer->getSingularForm($wrong);
 	}
 
 	public function testSingularizeSingularForm(): void {
-		$pluralizer = new EnglishPluralizer();
+		$pluralizer = new Inflector();
 		$this->assertEquals('book', $pluralizer->getSingularForm('book'), '`book` is already singular.');
 		$this->assertEquals('Book', $pluralizer->getSingularForm('Book'), '`Book` is already singular.');
 		$this->assertEquals('foot', $pluralizer->getSingularForm('foot'), '`foot` is already singular.');
@@ -152,7 +152,7 @@ class EnglishPluralizerTest extends TestCase {
 	}
 
 	public function testPluralizePluralForm(): void {
-		$pluralizer = new EnglishPluralizer();
+		$pluralizer = new Inflector();
 		$this->assertEquals('books', $pluralizer->getPluralForm('books'), '`books` is already plural.');
 		$this->assertEquals('Books', $pluralizer->getPluralForm('Books'), '`Books` is already plural.');
 		$this->assertEquals('feet', $pluralizer->getPluralForm('feet'), '`feet` is already plural.');
@@ -164,7 +164,7 @@ class EnglishPluralizerTest extends TestCase {
 	 * @dataProvider getPluralFormDataProvider
 	 */
 	public function testIsPlural($singular, $plural): void {
-		$pluralizer = new EnglishPluralizer();
+		$pluralizer = new Inflector();
 		$this->assertTrue($pluralizer->isPlural($plural));
 	}
 
@@ -172,7 +172,7 @@ class EnglishPluralizerTest extends TestCase {
 	 * @dataProvider getPluralFormDataProvider
 	 */
 	public function testIsSingular($singular, $plural): void {
-		$pluralizer = new EnglishPluralizer();
+		$pluralizer = new Inflector();
 		$this->assertTrue($pluralizer->isSingular($singular));
 	}
 }


### PR DESCRIPTION
Refactor the code to remove a lot of duplications between `phootwork\lang\ArrayObject` and `phootwork\collection`.

**Details**

- Extract `phootwork\lang\AbstractArray` superclass containing methods shared between `phootwork\lang\ArrayObject` and `phootwork\collection\AbstractCollection`
- Introduce `phootwork\lang\parts\array_parts` containing some traits that share methods between `ArrayObject` and the various collections into `phootwork\collection` namespace.
- Rename `EnglishPluralizer` to `Inflector` since this classis not only a pluralizer but also a singularizer. 