### PR TITLE
Fix issue #23

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ Contributing to a project is a process with its own rules and we try to explain 
 
 ## Quick Start for Experienced Programmers
 
-1. Fork, clone and apply your patches. See the [directory structure](#understanding-the directory-structure) explanation
+1. Fork, clone and apply your patches. See the [directory structure](#understanding-the-directory-structure) explanation
 if needed and don't forget to write tests.
 2. Run the test suite `composer test` and fix all red tests.
 3. Run static analysis tool (by now, we use [Psalm](https://psalm.dev/)) `composer analytics` and fix all errors and issues.

--- a/src/file/File.php
+++ b/src/file/File.php
@@ -30,34 +30,34 @@ class File {
 	 * 
 	 * @throws FileException
 	 *
-	 * @return string contents
+	 * @return Text contents
 	 */
-	public function read(): string {
+	public function read(): Text {
 		if (!$this->exists()) {
-			throw new FileException(sprintf('File does not exist: %s', $this->getFilename()));
+			throw new FileException(sprintf('File does not exist: %s', $this->getFilename()->toString()));
 		}
 
 		if (!$this->isReadable()) {
-			throw new FileException(sprintf('You don\'t have permissions to access %s file', $this->getFilename()));
+			throw new FileException(sprintf('You don\'t have permissions to access %s file', $this->getFilename()->toString()));
 		}
 
-		return file_get_contents($this->pathname);
+		return new Text(file_get_contents($this->pathname));
 	}
 
 	/**
 	 * Writes contents to the file
 	 *
-	 * @param string $contents
+	 * @param string|Text $contents
 	 *
 	 * @throws FileException
 	 *
 	 * @return $this
 	 */
-	public function write(string $contents): self {
+	public function write($contents): self {
 		$dir = new Directory($this->getDirname());
 		$dir->make();
 
-		file_put_contents($this->pathname, $contents);
+		file_put_contents($this->pathname, (string) $contents);
 
 		return $this;
 	}

--- a/src/file/FileOperationTrait.php
+++ b/src/file/FileOperationTrait.php
@@ -33,43 +33,43 @@ trait FileOperationTrait {
 	 * @param string|Text $pathname
 	 */
 	protected function init($pathname): void {
-		$this->pathname = '' . $pathname; // "cast" to string
+		$this->pathname = (string) $pathname;
 	}
 
 	/**
 	 * Returns the file extensions
 	 *
-	 * @return string the file extension
+	 * @return Text the file extension
 	 */
-	public function getExtension(): string {
-		return pathinfo($this->pathname, PATHINFO_EXTENSION);
+	public function getExtension(): Text {
+		return new Text(pathinfo($this->pathname, PATHINFO_EXTENSION));
 	}
 
 	/**
 	 * Returns the filename
 	 *
-	 * @return string the filename
+	 * @return Text the filename
 	 */
-	public function getFilename(): string {
-		return basename($this->pathname);
+	public function getFilename(): Text {
+		return new Text(basename($this->pathname));
 	}
 
 	/**
 	 * Gets the path without filename
 	 *
-	 * @return string
+	 * @return Text
 	 */
-	public function getDirname(): string {
-		return dirname($this->pathname);
+	public function getDirname(): Text {
+		return new Text(dirname($this->pathname));
 	}
 
 	/**
 	 * Gets the path to the file
 	 *
-	 * @return string
+	 * @return Text
 	 */
-	public function getPathname(): string {
-		return $this->pathname;
+	public function getPathname(): Text {
+		return new Text($this->pathname);
 	}
 
 	/**
@@ -301,14 +301,14 @@ trait FileOperationTrait {
 	 * If the destination file already exists, it will be overwritten.
 	 *
 	 *
-	 * @param string|Path $destination The destination path.
+	 * @param string|Text|Path $destination The destination path.
 	 *
 	 * @throws FileException When an error appeared.
 	 */
 	public function copy($destination): void {
 		$destination = $this->getDestination($destination);
 
-		if (!@copy($this->getPathname(), $destination->toString())) {
+		if (!@copy($this->getPathname()->toString(), $destination->toString())) {
 			throw new FileException(sprintf('Failed to copy %s to %s', $this->pathname, (string) $destination));
 		}
 	}
@@ -316,14 +316,14 @@ trait FileOperationTrait {
 	/**
 	 * Moves the file
 	 *
-	 * @param string|Path $destination
+	 * @param string|Text|Path $destination
 	 *
 	 * @throws FileException When an error appeared.
 	 */
 	public function move($destination): void {
 		$destination = $this->getDestination($destination);
 
-		if (@rename($this->getPathname(), $destination->toString())) {
+		if (@rename($this->getPathname()->toString(), $destination->toString())) {
 			$this->pathname = (string) $destination;
 		} else {
 			throw new FileException(sprintf('Failed to move %s to %s', $this->pathname, (string) $destination));
@@ -333,14 +333,14 @@ trait FileOperationTrait {
 	/**
 	 * Transforms destination into path and ensures, parent directory exists
 	 *
-	 * @param string|Path $destination
+	 * @param string|Text|Path $destination
 	 *
 	 * @throws FileException
 	 *
 	 * @return Path
 	 */
 	private function getDestination($destination): Path {
-		$destination = $destination instanceof Path ? $destination : new Path($destination);
+		$destination = $destination instanceof Path ? $destination : new Path((string) $destination);
 		$targetDir = new Directory($destination->getDirname());
 		$targetDir->make();
 
@@ -370,7 +370,7 @@ trait FileOperationTrait {
 			}
 		}
 
-		if (!$ok && @symlink($this->pathname, $target->getPathname()) !== true) {
+		if (!$ok && @symlink($this->pathname, $target->getPathname()->toString()) !== true) {
 			$report = error_get_last();
 			if (is_array($report) && DIRECTORY_SEPARATOR === '\\' && strpos($report['message'], 'error code(1314)') !== false) {
 				throw new FileException('Unable to create symlink due to error code 1314: \'A required privilege is not held by the client\'. Do you have the required Administrator-rights?');

--- a/src/file/Path.php
+++ b/src/file/Path.php
@@ -61,28 +61,28 @@ class Path {
 	/**
 	 * Returns the extension
 	 * 
-	 * @return string the extension
+	 * @return Text the extension
 	 */
-	public function getExtension(): string {
-		return $this->extension;
+	public function getExtension(): Text {
+		return new Text($this->extension);
 	}
 
 	/**
 	 * Returns the filename
 	 *
-	 * @return string the filename
+	 * @return Text the filename
 	 */
-	public function getFilename(): string {
-		return $this->filename;
+	public function getFilename(): Text {
+		return new Text($this->filename);
 	}
 
 	/**
 	 * Gets the path without filename
 	 *
-	 * @return string
+	 * @return Text
 	 */
-	public function getDirname(): string {
-		return $this->stream . $this->dirname;
+	public function getDirname(): Text {
+		return new Text($this->stream . $this->dirname);
 	}
 
 	/**
@@ -104,11 +104,11 @@ class Path {
 	/**
 	 * Changes the extension of this path
 	 * 
-	 * @param string $extension the new extension
+	 * @param string|Text $extension the new extension
 	 *
 	 * @return $this
 	 */
-	public function setExtension(string $extension): self {
+	public function setExtension($extension): self {
 		$pathinfo = pathinfo($this->pathname->toString());
 
 		$pathname = new Text($pathinfo['dirname']);
@@ -119,7 +119,7 @@ class Path {
 		$this->init($pathname
 			->append($pathinfo['filename'])
 			->append('.')
-			->append($extension))
+			->append((string) $extension))
 		;
 
 		return $this;

--- a/src/xml/XmlParser.php
+++ b/src/xml/XmlParser.php
@@ -124,12 +124,12 @@ class XmlParser {
 	/**
 	 * Parses a string
 	 *
-	 * @param string $data
+	 * @param string|Text $data
 	 *
 	 * @throws XmlException
 	 */
 	public function parse($data): void {
-		if (!xml_parse($this->parser, $data)) {
+		if (!xml_parse($this->parser, (string) $data)) {
 			$code = xml_get_error_code($this->parser);
 
 			throw new XmlException(xml_error_string($code), $code);

--- a/tests/file/FileDescriptorTest.php
+++ b/tests/file/FileDescriptorTest.php
@@ -21,9 +21,9 @@ class FileDescriptorTest extends FilesystemTest {
 		$this->assertTrue(File::create('') instanceof File);
 		$this->assertTrue(FileDescriptor::create('') instanceof FileDescriptor);
 
-		$this->assertTrue(is_string(File::create('/path/to/dir')->getPathname()));
-		$this->assertTrue(is_string(Directory::create(new Path('/path/to/dir'))->getPathname()));
-		$this->assertTrue(is_string(FileDescriptor::create(new Text('/path/to/dir'))->getPathname()));
+		$this->assertInstanceOf(Text::class, File::create('/path/to/dir')->getPathname());
+		$this->assertInstanceOf(Text::class, Directory::create(new Path('/path/to/dir'))->getPathname());
+		$this->assertInstanceOf(Text::class, FileDescriptor::create(new Text('/path/to/dir'))->getPathname());
 	}
 
 	public function testNames(): void {

--- a/tests/file/LinkTest.php
+++ b/tests/file/LinkTest.php
@@ -45,8 +45,8 @@ class LinkTest extends TestCase {
 	}
 
 	public function testLink(): void {
-		$origin = new Path(tempnam($this->tempDir->getPathname(), 'orig'));
-		$target = new File(tempnam($this->tempDir->getPathname(), 'target'));
+		$origin = new Path(tempnam((string) $this->tempDir->getPathname(), 'orig'));
+		$target = new File(tempnam((string) $this->tempDir->getPathname(), 'target'));
 		$target->delete();
 		$target = new Path($target->getPathname());
 
@@ -62,8 +62,8 @@ class LinkTest extends TestCase {
 	}
 
 	public function testLinkToAdifferentLink(): void {
-		$origin = new Path(tempnam($this->tempDir->getPathname(), 'orig'));
-		$target = new File(tempnam($this->tempDir->getPathname(), 'target'));
+		$origin = new Path(tempnam((string) $this->tempDir->getPathname(), 'orig'));
+		$target = new File(tempnam((string) $this->tempDir->getPathname(), 'target'));
 		$target->delete();
 		$target = new Path($target->getPathname());
 
@@ -74,7 +74,7 @@ class LinkTest extends TestCase {
 		$this->assertTrue($link->exists());
 		$this->assertTrue($link->isLink());
 
-		$origin2 = new Path(tempnam($this->tempDir->getPathname(), '2orig'));
+		$origin2 = new Path(tempnam((string) $this->tempDir->getPathname(), '2orig'));
 		$file2 = new File($origin2);
 		$file2->touch();
 		$file2->linkTo($target);

--- a/tests/file/PathTest.php
+++ b/tests/file/PathTest.php
@@ -19,11 +19,11 @@ class PathTest extends TestCase {
 
 		$this->assertEquals('this/is/the/path/to/my', $p->getDirname());
 		$this->assertEquals('file.ext', $p->getFilename());
-		$this->assertEquals('ext', $p->getExtension());
-		$this->assertEquals('this/is/the/path/to/my/file.ext', $p->getPathname());
+		$this->assertEquals('ext', $p->getExtension()->toString());
+		$this->assertEquals('this/is/the/path/to/my/file.ext', $p->getPathname()->toString());
 
 		$p = new Path('another/path');
-		$this->assertEmpty($p->getExtension());
+		$this->assertTrue($p->getExtension()->isEmpty());
 		$p = $p->append('to');
 		$this->assertEquals('another/path/to', $p->getPathname());
 		$p = $p->append(new Path('my/stuff'));
@@ -41,7 +41,7 @@ class PathTest extends TestCase {
 		$p = new Path('my/file.ext');
 		$this->assertEquals('ext', $p->getExtension());
 		$this->assertEquals('bla', $p->setExtension('bla')->getExtension());
-		$this->assertEmpty($p->removeExtension()->getExtension());
+		$this->assertTrue($p->removeExtension()->getExtension()->isEmpty());
 	}
 
 	public function testSegments(): void {


### PR DESCRIPTION
All methods of `phootwork\file` classes now return `phootwork\lang\Text` instead of `string` and accept Text objects or strings, instead of string only, as parameters.