### PR TITLE
Fix a bug discovered by Scrutinizer

### DIFF
--- a/src/collection/AbstractCollection.php
+++ b/src/collection/AbstractCollection.php
@@ -42,7 +42,7 @@ abstract class AbstractCollection extends AbstractArray implements Collection {
 	/**
 	 * @internal
 	 */
-	public function key(): int {
+	public function key() {
 		return key($this->array);
 	}
 

--- a/src/file/FileOperationTrait.php
+++ b/src/file/FileOperationTrait.php
@@ -19,6 +19,11 @@ trait FileOperationTrait {
 	protected $pathname;
 
 	/**
+	 * @param string|Text $pathname
+	 */
+	abstract public function __construct($pathname);
+
+	/**
 	 * Static instantiator
 	 *
 	 * @param string|Text $pathname

--- a/src/lang/parts/IndexFindersPart.php
+++ b/src/lang/parts/IndexFindersPart.php
@@ -10,6 +10,9 @@
 namespace phootwork\lang\parts;
 
 trait IndexFindersPart {
+	abstract public function find(...$arguments);
+
+	abstract public function findLast(...$arguments);
 
 	/**
 	 * Returns the index of the given element or false if the element can't be found
@@ -21,7 +24,7 @@ trait IndexFindersPart {
 	public function indexOf($element): ?int {
 		$out = array_search($element, $this->array, true);
 
-		return false === $out ? null : $out;
+		return false === $out ? null : (int) $out;
 	}
 
 	/**

--- a/tests/collection/AbstractCollectionTest.php
+++ b/tests/collection/AbstractCollectionTest.php
@@ -11,6 +11,7 @@ namespace phootwork\collection\tests;
 
 use phootwork\collection\ArrayList;
 use phootwork\collection\CollectionUtils;
+use phootwork\collection\Map;
 use PHPUnit\Framework\TestCase;
 
 class AbstractCollectionTest extends TestCase {
@@ -55,6 +56,28 @@ class AbstractCollectionTest extends TestCase {
 		$this->assertEquals(2, $counter);
 		$this->assertSame($data, $elements);
 		$this->assertSame($elements, $keyelems);
+	}
+
+	public function testIteratorAssociative(): void {
+		$data = ['item_1' => 'Item 1', 'item_2' => 'Item 2'];
+		$map = new Map($data);
+		$elements = [];
+		$keyElements = [];
+		$counter = 0;
+
+		foreach ($map as $key => $element) {
+			$keyElements[$key] = $element;
+			$counter++;
+		}
+
+		foreach ($map as $element) {
+			$elements[] = $element;
+		}
+
+		$this->assertEquals(2, $counter);
+		$this->assertCount(2, $elements);
+		$this->assertSame($data, $keyElements);
+		$this->assertSame(array_values($data), $elements);
 	}
 
 	public function testExport(): void {


### PR DESCRIPTION
If `phootwork\collection\AbstractCollection::key()` method is type-hinted to int, then `phootwork\collection\Map` class throws an exception when using it.
I added a test to prove this behavior (it fails without this commit).