### PR TITLE
Change monorepo-tools repository

### DIFF
--- a/bin/auto_split.sh
+++ b/bin/auto_split.sh
@@ -9,7 +9,7 @@ then
   then
     if [ ${TRAVIS_PULL_REQUEST} = "false" ]
     then
-      git clone https://github.com/shopsys/monorepo-tools
+      git clone https://github.com/cristianoc72/monorepo-tools
       git remote add dep_collection https://${GITHUB_TOKEN}@github.com/phootwork/collection
       git remote add dep_file https://${GITHUB_TOKEN}@github.com/phootwork/file
       git remote add dep_json https://${GITHUB_TOKEN}@github.com/phootwork/json


### PR DESCRIPTION
`lang` and `collection` packages are not correctly updated when push to the monorepo:
Github rejects the pushes because they're not fast-forward. Even if I have been very careful, maybe I did something wrong in the early stage of the monorepo development, I don't know.

Anyway, looking at monorepo-tools documentation and solved issues, monorepo-tools guys suggest to fix this behavior by modifying `monorepo_split.sh` script to force push.
I did it https://github.com/cristianoc72/monorepo-tools/blob/master/monorepo_split.sh#L36 and changed `bin/auto_split.sh` to use the modified version.