### PR TITLE
Move IndexFindersPart from AbstractList to ArrayList

### DIFF
--- a/src/collection/AbstractList.php
+++ b/src/collection/AbstractList.php
@@ -11,7 +11,6 @@ namespace phootwork\collection;
 
 use phootwork\lang\Comparator;
 use phootwork\lang\parts\EachPart;
-use phootwork\lang\parts\IndexFindersPart;
 use phootwork\lang\parts\ReducePart;
 use phootwork\lang\parts\RemovePart;
 use phootwork\lang\parts\ReversePart;
@@ -24,11 +23,6 @@ use phootwork\lang\parts\ReversePart;
  */
 abstract class AbstractList extends AbstractCollection {
 	use EachPart;
-	use IndexFindersPart {
-		indexOf as traitIndexOf;
-		findLastIndex as traitFindLastIndex;
-		findIndex as traitFindIndex;
-	}
 	use ReducePart;
 	use RemovePart;
 	use ReversePart;
@@ -45,64 +39,5 @@ abstract class AbstractList extends AbstractCollection {
 	 */
 	public function reverseSort($cmp = null): self {
 		return $this->sort($cmp)->reverse();
-	}
-
-	/**
-	 * Returns the index of the given element or null if the element can't be found
-	 *
-	 * @param mixed $element
-	 *
-	 * @return int the index for the given element
-	 */
-	public function indexOf($element): ?int {
-		$index = $this->traitIndexOf($element);
-
-		return $index === null ? $index : (int) $index;
-	}
-
-	/**
-	 * Searches the array with a given callback and returns the index for the last element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 * When it's passed, $query must be the first argument:
-	 *
-	 *     - find($query, callback)
-	 *     - find(callback)
-	 *
-	 * @param array $arguments
-	 *
-	 * @return int|null the index or null if it hasn't been found
-	 */
-	public function findLastIndex(...$arguments): ?int {
-		$lastIndex = $this->traitFindLastIndex(...$arguments);
-
-		return $lastIndex === null ? $lastIndex : (int) $lastIndex;
-	}
-
-	/**
-	 * Searches the array with a given callback and returns the index for the first element if found.
-	 *
-	 * The callback function takes one or two parameters:
-	 *
-	 *     function ($element [, $query]) {}
-	 *
-	 * The callback must return a boolean
-	 * When it's passed, $query must be the first argument:
-	 *
-	 *     - find($query, callback)
-	 *     - find(callback)
-	 *
-	 * @param array $arguments
-	 *
-	 * @return int|null the index or null if it hasn't been found
-	 */
-	public function findIndex(...$arguments): ?int {
-		$index = $this->traitFindIndex(...$arguments);
-
-		return $index === null ? $index : (int) $index;
 	}
 }

--- a/src/collection/ArrayList.php
+++ b/src/collection/ArrayList.php
@@ -12,6 +12,7 @@ namespace phootwork\collection;
 use Iterator;
 use phootwork\lang\parts\AccessorsPart;
 use phootwork\lang\parts\AddPart;
+use phootwork\lang\parts\IndexFindersPart;
 use phootwork\lang\parts\InsertPart;
 
 /**
@@ -25,6 +26,11 @@ class ArrayList extends AbstractList {
 		get as traitGet;
 	}
 	use AddPart;
+	use IndexFindersPart {
+		indexOf as traitIndexOf;
+		findLastIndex as traitFindLastIndex;
+		findIndex as traitFindIndex;
+	}
 	use InsertPart;
 
 	/**
@@ -62,5 +68,64 @@ class ArrayList extends AbstractList {
 	 */
 	public function get(int $index) {
 		return $this->traitGet($index);
+	}
+
+	/**
+	 * Returns the index of the given element or null if the element can't be found
+	 *
+	 * @param mixed $element
+	 *
+	 * @return int the index for the given element
+	 */
+	public function indexOf($element): ?int {
+		$index = $this->traitIndexOf($element);
+
+		return $index === null ? $index : (int) $index;
+	}
+
+	/**
+	 * Searches the array with a given callback and returns the index for the last element if found.
+	 *
+	 * The callback function takes one or two parameters:
+	 *
+	 *     function ($element [, $query]) {}
+	 *
+	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
+	 *
+	 *     - find($query, callback)
+	 *     - find(callback)
+	 *
+	 * @param array $arguments
+	 *
+	 * @return int|null the index or null if it hasn't been found
+	 */
+	public function findLastIndex(...$arguments): ?int {
+		$lastIndex = $this->traitFindLastIndex(...$arguments);
+
+		return $lastIndex === null ? $lastIndex : (int) $lastIndex;
+	}
+
+	/**
+	 * Searches the array with a given callback and returns the index for the first element if found.
+	 *
+	 * The callback function takes one or two parameters:
+	 *
+	 *     function ($element [, $query]) {}
+	 *
+	 * The callback must return a boolean
+	 * When it's passed, $query must be the first argument:
+	 *
+	 *     - find($query, callback)
+	 *     - find(callback)
+	 *
+	 * @param array $arguments
+	 *
+	 * @return int|null the index or null if it hasn't been found
+	 */
+	public function findIndex(...$arguments): ?int {
+		$index = $this->traitFindIndex(...$arguments);
+
+		return $index === null ? $index : (int) $index;
 	}
 }


### PR DESCRIPTION
Since `phootwork\collection\Set` doesn't care about collection indexes, we move `IndexFindersPart` from `AbstractList` to `ArrayList`.