### PR TITLE
Adjust Stack and Queue collections

### DIFF
--- a/src/collection/Queue.php
+++ b/src/collection/Queue.php
@@ -34,26 +34,13 @@ class Queue extends AbstractList {
 	/**
 	 * Enqueues an element
 	 * 
-	 * @param mixed $element
+	 * @param mixed ...$elements
 	 *
 	 * @return $this
 	 */
-	public function enqueue($element): self {
-		array_unshift($this->array, $element);
-
-		return $this;
-	}
-
-	/**
-	 * Enqueues many elements
-	 *
-	 * @param array|Iterator $collection
-	 *
-	 * @return $this
-	 */
-	public function enqueueAll($collection): self {
-		foreach ($collection as $element) {
-			$this->enqueue($element);
+	public function enqueue(...$elements): self {
+		foreach ($elements as $element) {
+			array_unshift($this->array, $element);
 		}
 
 		return $this;

--- a/src/collection/Stack.php
+++ b/src/collection/Stack.php
@@ -28,32 +28,19 @@ class Stack extends AbstractList {
 	 * @param array|Iterator $collection
 	 */
 	public function __construct($collection = []) {
-		$this->pushAll($collection);
+		$this->push(...$collection);
 	}
 
 	/**
 	 * Pushes an element onto the stack
 	 * 
-	 * @param mixed $element
+	 * @param mixed ...$elements
 	 *
 	 * @return $this
 	 */
-	public function push($element): self {
-		array_push($this->array, $element);
-
-		return $this;
-	}
-
-	/**
-	 * Pushes many elements onto the stack
-	 *
-	 * @param array|Iterator $collection
-	 *
-	 * @return $this
-	 */
-	public function pushAll($collection): self {
-		foreach ($collection as $element) {
-			$this->push($element);
+	public function push(...$elements): self {
+		foreach ($elements as $element) {
+			array_push($this->array, $element);
 		}
 
 		return $this;

--- a/tests/collection/QueueTest.php
+++ b/tests/collection/QueueTest.php
@@ -27,7 +27,7 @@ class QueueTest extends TestCase {
 
 		$this->assertEquals(0, $queue->size());
 
-		$queue->enqueueAll($items);
+		$queue->enqueue(...$items);
 
 		$this->assertEquals(2, $queue->size());
 

--- a/tests/collection/StackTest.php
+++ b/tests/collection/StackTest.php
@@ -17,7 +17,6 @@ class StackTest extends TestCase {
 		$item1 = 'item 1';
 		$item2 = 'item 2';
 		$item3 = 'item 3';
-		$items = [$item1, $item2];
 
 		$stack = new Stack();
 		$stack->push($item1);
@@ -27,13 +26,20 @@ class StackTest extends TestCase {
 
 		$this->assertEquals(0, $stack->size());
 
-		$stack->pushAll($items);
+		$stack->push($item1, $item2);
 
 		$this->assertEquals(2, $stack->size());
 
 		$stack->push($item3);
 
 		$this->assertEquals(3, $stack->size());
+	}
+
+	public function testsAddWithIterator(): void {
+		$iterator = new \ArrayIterator(['item 1', 'item 2', 'item 3']);
+		$stack = new Stack($iterator);
+
+		$this->assertEquals('item 3', $stack->pop());
 	}
 
 	public function testToArray(): void {
@@ -47,7 +53,7 @@ class StackTest extends TestCase {
 		$this->assertEquals($stack->toArray(), ['item 1', 'item 2', 'item 3']);
 
 		$stack = new Stack();
-		$stack->pushAll(['item 1', 'item 2', 'item 3']);
+		$stack->push('item 1', 'item 2', 'item 3');
 		$this->assertSame('item 3', $stack->peek());
 		$this->assertEquals($stack->toArray(), ['item 1', 'item 2', 'item 3']);
 	}

--- a/tests/xml/XmlParserTest.php
+++ b/tests/xml/XmlParserTest.php
@@ -52,7 +52,7 @@ class XmlParserTest extends TestCase {
 
 		$stack->push('database');
 		$stack->push('entity');
-		$stack->pushAll(['field', 'field', 'field', 'field', 'relation', 'relation']);
+		$stack->push('field', 'field', 'field', 'field', 'relation', 'relation');
 		//$stack = $stack->map(function ($item) {
 		//	return strtoupper($item);
 		//});


### PR DESCRIPTION
Refactor `Stack::push` and `Queue::enqueue` to be consistent with `add()`method of the other collections.
Remove `Stack::pushAll` and `Queue::enqueueAll`.

After merging this PR, we're ready to 2.0 version,imho.