### PR TITLE
Fix scripts run by Travis Ci

### DIFF
--- a/bin/auto_split.sh
+++ b/bin/auto_split.sh
@@ -4,8 +4,8 @@
 # corresponding to the minumim php version supported
 if [ ${TRAVIS_PHP_VERSION} = "7.2" ]
 then
-  # Run the commands only when push on master branch
-  if [ ${TRAVIS_BRANCH} = "master" ]
+  # Run the commands only when push on master branch or when a new tag is added
+  if [ ${TRAVIS_BRANCH} = "master" ] || [ ${TRAVIS_BRANCH} = ${TRAVIS_TAG} ]
   then
     if [ ${TRAVIS_PULL_REQUEST} = "false" ]
     then

--- a/bin/build_api.sh
+++ b/bin/build_api.sh
@@ -4,8 +4,8 @@
 # corresponding to the minumim php version supported
 if [ ${TRAVIS_PHP_VERSION} = "7.2" ]
 then
-  # Run the commands only when push on master branch
-  if [ ${TRAVIS_BRANCH} = "master" ]
+  # Run the commands only when push on master branch or when a new tag is added
+  if [ ${TRAVIS_BRANCH} = "master" ] || [ ${TRAVIS_BRANCH} = ${TRAVIS_TAG} ]
   then
     if [ ${TRAVIS_PULL_REQUEST} = "false" ]
     then


### PR DESCRIPTION
Fix `bin/auto_split.sh` and `bin/build_api.sh` to run also when a new tag is added.

Otherwise, when we draft a new release, the libraries repositories aren't updated (see 2.0-alpha version).