### PR TITLE
Fix queue constructor

### DIFF
--- a/src/collection/Queue.php
+++ b/src/collection/Queue.php
@@ -26,9 +26,7 @@ class Queue extends AbstractList {
 	 * @param array|Iterator $collection
 	 */
 	public function __construct($collection = []) {
-		foreach ($collection as $element) {
-			$this->array[] = $element;
-		}
+		$this->enqueue(...$collection);
 	}
 
 	/**
@@ -39,8 +37,9 @@ class Queue extends AbstractList {
 	 * @return $this
 	 */
 	public function enqueue(...$elements): self {
-		foreach ($elements as $element) {
-			array_unshift($this->array, $element);
+		//Workaround for PHP 7.2
+		if ($elements !== []) {
+			array_unshift($this->array, ...$elements);
 		}
 
 		return $this;


### PR DESCRIPTION
I'm awfully sorry to come back on issue #38 but this commit is the only way I can find to make Queue work: enqueue at the end and poll from the top.

In this way, all tests are ok and the manipulations on the array, returned from `toArray` function, are the same as using the collection (see QueueTest::testMap).

@gossi please, test the code and share those examples that don't work as expected

This PR fixes #42 