### PR TITLE
Introduce Github Actions

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -1,0 +1,26 @@
+# Run coverage report and upload it
+name: Coverage
+on:
+  push:
+    branches: [master]
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: 7.2
+          extensions: mbstring, dom, json, libxml, xml, xmlwriter
+          coverage: xdebug
+      - name: Install dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+      - name: Test & publish code coverage
+        uses: paambaati/codeclimate-action@v2.3.0
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        with:
+          coverageCommand: "composer coverage:clover"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+# Run Test Suite
+name: Tests
+on: [push, pull_request]
+jobs:
+  test:
+    name: test
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+        php-versions: ['7.2', '7.3', '7.4']
+    runs-on: ${{ matrix.operating-system }}
+    steps:
+      - run: git config --global core.autocrlf false
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v1
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring, dom, json, libxml, xml, xmlwriter
+          coverage: xdebug
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache composer dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install dependencies
+        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
+      - name: Check code style
+        run: composer cs
+      - name: Test with phpunit
+        run: composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,10 @@ sudo: false
 php:
   - 7.2
   - 7.3
-  - nightly
+  - 7.4
 
 install:
   - composer install
-
-before_script:
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
 
 script:
   - composer cs
@@ -22,7 +17,6 @@ script:
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover clover.xml
-  - ./cc-test-reporter after-build --coverage-input-type clover --exit-code $TRAVIS_TEST_RESULT
 
 after_success:
   - bin/auto_split.sh
@@ -35,4 +29,3 @@ matrix:
 env:
   global:
     - secure: A5X6qEt2zkieTWeUDa0cHrMtMWinb9QzdR4Jn5NdcffHVBWOvPahKA8u6yoS9mt+/Ohk4z7HNj+AztLQW81X1Zox4Ogm8oN4qPjTNHhZZHrddj5aKBnbnX9mF5X0rRty/j01/HQ9+mFOIAWAc83laBXCK4nu3AGVobytR3t6zklf4iJWFJ4CxSqOPEVrAU9FNkaDW99XQpDWfckki/rBuyuPzgdrCdU+QgRqZzX9n6MJw/d5WE1nN7mlarlljqu/Q7y4t+JnSzG3DzCjPoD6AzEyPFZm/9mxcn9YqKQemOsYk73Gsi3tZNbcOV2c/KZ24cX3TrQgIkUKKbBFNvc/wS0DPQ5so1piKDZX/u3asDnzj+2/C9tog4P1l5snY8elTkqR9T8uWdVqzMkGVdqDcOWArz8zFlWbAfGLf5e03cYDW7oW6tYQwkU44W8w8cs4CPc0U1qRfm4J1E3nJwDS+rRHsHRuYQrjBRgpJSMT2NYlicbaP07gWqTWTvLvnOVLu5rHSI4a0xcHLHWQH7Vse54E+/lI27kAFDoElc4tE3qr7YQa1RbH5L/qqDySELnaN4bNGqhJBd2iZg3lYB7zBBkZGIVNdiRhOHlPrFDdxhCJwTm+LPBJVWsQYWh33cX3h6sgw/ru6LGZbExfosCU4E/69g091NO1QeWkOGaiMmA=
-    - CC_TEST_REPORTER_ID=5b17932a3c56d5343d62906e2c402cbb43a7766e0f0652bd271441b1cd5163d6

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Phootwork library
 
+![](https://github.com/actions/phootwork/workflows/Tests/badge.svg)
+![](https://github.com/actions/phootwork/workflows/Coverage/badge.svg)
 [![Build Status](https://travis-ci.org/phootwork/phootwork.svg?branch=master)](https://travis-ci.org/phootwork/phootwork)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/phootwork/phootwork/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/phootwork/phootwork/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/phootwork/phootwork/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/phootwork/phootwork/?branch=master)

--- a/composer.json
+++ b/composer.json
@@ -61,21 +61,23 @@
     }
   },
   "scripts": {
-    "analytics": "vendor/bin/psalm",
+    "analytics": "psalm",
     "check": [
       "@test",
       "@analytics",
       "@cs-fix"
     ],
-    "coverage": "@test --coverage-html coverage/",
+    "coverage:html": "@test --coverage-html coverage/",
+    "coverage:clover": "@test --coverage-clover clover.xml",
     "cs": "php-cs-fixer fix -v --diff --dry-run",
     "cs-fix": "php-cs-fixer fix -v --diff",
-    "test": "vendor/bin/phpunit"
+    "test": "phpunit"
   },
   "scripts-descriptions": {
     "analytics": "Run static analysis tool",
     "check": "Perform all tests and analysis, required before submitting a pull request",
-    "coverage": "Create a code coverage report in html format, into the `coverage/` directory",
+    "coverage:html": "Create a code coverage report in html format, into the `coverage/` directory",
+    "coverage:clover": "Create a code coverage report in format, into clover.xml file",
     "cs": "Run code style analysis, without fixing errors",
     "cs-fix": "Run code style analysis and fix errors",
     "test": "Run all tests"

--- a/src/file/Path.php
+++ b/src/file/Path.php
@@ -340,7 +340,7 @@ class Path {
 	/**
 	 * Returns the segments in this path in order.
 	 * 
-	 * @return ArrayObject<string>
+	 * @return ArrayObject
 	 */
 	public function segments(): ArrayObject {
 		return $this->segments;

--- a/tests/file/LinkTest.php
+++ b/tests/file/LinkTest.php
@@ -12,6 +12,7 @@ namespace phootwork\file\tests;
 use phootwork\file\Directory;
 use phootwork\file\File;
 use phootwork\file\Path;
+use phootwork\lang\Text;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -30,6 +31,10 @@ class LinkTest extends TestCase {
 	private $tempDir;
 
 	public function setUp(): void {
+		if ((new Text(PHP_OS))->toUpperCase()->contains('WIN')) {
+			$this->markTestSkipped('To investigate: symlinks don\'t work on Windows.');
+		}
+
 		$this->tempDir = new Directory(sys_get_temp_dir() . '/phootwork');
 		//if some errors, sometimes tearDown is not called
 		if ($this->tempDir->exists()) {


### PR DESCRIPTION
-  Added 2 workflows:
    1.  `test.yml` to run the test suite on different OS and against different PHP versions
    2.  `coverage_report.yml` to upload the coverage report on CodeClimate, removing it from Travis
-  Adjust composer scripts to correctly run in the new environment.

Note 1: the coverage report workflow runs again the tests, because different workflows are completely separate each other.

Note 2: I marked two tests skipped on Windows: after some investigation and headache, I can't understand why symlinks don't work on windows. Anyway, googling around it seems they're the *bete noire* of all PHP developers on that OS.