### PR TITLE
Adjust version of required libraries

### DIFF
--- a/src/collection/composer.json
+++ b/src/collection/composer.json
@@ -31,7 +31,7 @@
 	},
 	"require" : {
 		"php" : ">=7.2",
-		"phootwork/lang" : "^2.0"
+		"phootwork/lang" : "2.0@dev"
 	},
 	"homepage" : "https://phootwork.github.io/collection/"
 }

--- a/src/file/composer.json
+++ b/src/file/composer.json
@@ -22,7 +22,7 @@
 	},
 	"require" : {
 		"php" : ">=7.2",
-		"phootwork/lang" : "^2.0"
+		"phootwork/lang" : "2.0@dev"
 	},
 	"homepage" : "https://phootwork.github.io/file/"
 }

--- a/src/json/composer.json
+++ b/src/json/composer.json
@@ -21,7 +21,7 @@
 	},
 	"require" : {
 		"php" : ">=7.2",
-		"phootwork/collection" : "^2.0"
+		"phootwork/collection" : "2.0@dev"
 	},
 	"homepage" : "https://phootwork.github.io/json/"
 }

--- a/src/tokenizer/composer.json
+++ b/src/tokenizer/composer.json
@@ -21,6 +21,6 @@
 	},
 	"require" : {
 		"php" : ">=7.2",
-		"phootwork/collection" : "^2.0"
+		"phootwork/collection" : "2.0@dev"
 	}
 }

--- a/src/xml/composer.json
+++ b/src/xml/composer.json
@@ -20,7 +20,7 @@
 	"require" : {
 		"php" : ">=7.2",
 		"ext-xml": "*",
-		"phootwork/collection" : "^2.0",
-		"phootwork/file" : "^2.0"
+		"phootwork/collection" : "2.0@dev",
+		"phootwork/file" : "2.0@dev"
 	}
 }


### PR DESCRIPTION
Adjust versions of the required packages, so that the libraries can be installed separately, also in pre-release versions.

The relative versions should be set again to `^2.0`, before release a v2.0 stable.