### PR TITLE
Fix TokenCollection

### DIFF
--- a/src/tokenizer/TokenCollection.php
+++ b/src/tokenizer/TokenCollection.php
@@ -20,7 +20,7 @@ class TokenCollection extends ArrayList {
 	 *
 	 * @return Token 
 	 */
-	public function get(int $index): Token {
+	public function get(int $index): ?Token {
 		return parent::get($index);
 	}
 }

--- a/tests/tokenizer/TokenCollectionTest.php
+++ b/tests/tokenizer/TokenCollectionTest.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+/**
+ * This file is part of the Phootwork package.
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @license MIT License
+ * @copyright Thomas Gossmann
+ */
+namespace phootwork\tokenizer\tests;
+
+use phootwork\tokenizer\PhpTokenizer;
+use phootwork\tokenizer\Token;
+
+class TokenCollectionTest extends TokenizerTest {
+	public function testGetMethod(): void {
+		$sample = $this->getSample('class');
+
+		$tokenizer = new PhpTokenizer();
+		$tokens = $tokenizer->tokenize($sample);
+
+		$this->assertEquals(99, $tokens->size(), 'The fixture class has 99 tokens');
+		$this->assertInstanceOf(Token::class, $tokens->get(55));
+		$this->assertNull($tokens->get(500));
+	}
+}


### PR DESCRIPTION
Adjust `phootwork\tokenizer\TokenCollection::get()` method to return null, for consistency with `phootwork\lang\ArrayList::get`.

With this commit, you can use the `??` operator in conjunction with `get()` method:

```php
<?php

function getToken(TokenCollection $collection): Token {
    $index = 0;

    //some $index manipulations
   ..........

    return $collection->get($index) ?? new Token();
}
```

which is very useful, since `ArrayList` hasn't an `has()` method.
