### PR TITLE
Make collections countable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
     "coverage:clover": "@test --coverage-clover clover.xml",
     "cs": "php-cs-fixer fix -v --diff --dry-run",
     "cs-fix": "php-cs-fixer fix -v --diff",
-    "test": "phpunit"
+    "test": "phpunit --colors=always"
   },
   "scripts-descriptions": {
     "analytics": "Run static analysis tool",

--- a/src/lang/AbstractArray.php
+++ b/src/lang/AbstractArray.php
@@ -15,7 +15,7 @@ namespace phootwork\lang;
  *
  * @author Cristiano Cinotti
  */
-abstract class AbstractArray {
+abstract class AbstractArray implements \Countable {
 
 	/** @var array */
 	protected $array = [];

--- a/src/xml/XmlParser.php
+++ b/src/xml/XmlParser.php
@@ -79,7 +79,11 @@ class XmlParser {
 	}
 
 	public function __destruct() {
-		xml_parser_free($this->parser);
+		// Workaround for an error with php 7.3 on Windows and MacOs
+		// remove if condition when 7.3 version not supported anymore
+		if (is_resource($this->parser)) {
+			xml_parser_free($this->parser);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Since all Collections and ArrayObject already have the `count()` method, with this commit they also implement `Countable` interface, so that phootwork is completely compatible with other libraries, requiring that interface (i.e. [Twig loop](https://twig.symfony.com/doc/3.x/tags/for.html)).