### PR TITLE
Fix Psalm errors

### DIFF
--- a/src/collection/AbstractCollection.php
+++ b/src/collection/AbstractCollection.php
@@ -28,8 +28,8 @@ abstract class AbstractCollection extends AbstractArray implements Collection {
 	/**
 	 * @internal
 	 */
-	public function rewind() {
-		return reset($this->array);
+	public function rewind(): void {
+		reset($this->array);
 	}
 
 	/**
@@ -49,8 +49,8 @@ abstract class AbstractCollection extends AbstractArray implements Collection {
 	/**
 	 * @internal
 	 */
-	public function next() {
-		return next($this->array);
+	public function next(): void {
+		next($this->array);
 	}
 
 	/**

--- a/src/file/Directory.php
+++ b/src/file/Directory.php
@@ -14,6 +14,11 @@ use Iterator;
 use phootwork\file\exception\FileException;
 use phootwork\lang\Text;
 
+/**
+ * Class Directory
+ *
+ * @psalm-consistent-constructor
+ */
 class Directory implements Iterator {
 	use FileOperationTrait;
 

--- a/src/file/File.php
+++ b/src/file/File.php
@@ -13,6 +13,11 @@ use DateTime;
 use phootwork\file\exception\FileException;
 use phootwork\lang\Text;
 
+/**
+ * Class File
+ *
+ * @psalm-consistent-constructor
+ */
 class File {
 	use FileOperationTrait;
 

--- a/src/file/FileDescriptor.php
+++ b/src/file/FileDescriptor.php
@@ -11,6 +11,11 @@ namespace phootwork\file;
 
 use phootwork\lang\Text;
 
+/**
+ * Class FileDescriptor
+ *
+ * @psalm-consistent-constructor
+ */
 class FileDescriptor {
 	use FileOperationTrait;
 

--- a/src/lang/AbstractArray.php
+++ b/src/lang/AbstractArray.php
@@ -14,6 +14,8 @@ namespace phootwork\lang;
  * `phootwork\lang\ArrayObject` and `phootwork\class\AbstractCollection`
  *
  * @author Cristiano Cinotti
+ *
+ * @psalm-consistent-constructor
  */
 abstract class AbstractArray implements \Countable {
 

--- a/src/lang/parts/TransformationsPart.php
+++ b/src/lang/parts/TransformationsPart.php
@@ -189,7 +189,6 @@ trait TransformationsPart {
 	 * @psalm-suppress InvalidArgument argument 2 of preg_replace_callback CAN BE closure, too (see https://www.php.net/manual/en/function.preg-replace-callback.php)
 	 */
 	public function toStudlyCase(): Text {
-		/** @var Text $input */
 		$input = $this->trim('-_');
 		if ($input->isEmpty()) {
 			return $input;
@@ -197,7 +196,7 @@ trait TransformationsPart {
 		$encoding = $this->encoding;
 
 		return Text::create(preg_replace_callback('/([A-Z-_][a-z0-9]+)/', function (array $matches) use ($encoding) {
-			return Text::create($matches[0], $encoding)->replace(['-', '_'], '')->toUpperCaseFirst();
+			return Text::create($matches[0], $encoding)->replace(['-', '_'], '')->toUpperCaseFirst()->toString();
 		}, $input->toString()), $this->encoding)->toUpperCaseFirst();
 	}
 

--- a/src/xml/XmlParser.php
+++ b/src/xml/XmlParser.php
@@ -78,6 +78,10 @@ class XmlParser {
 		xml_set_unparsed_entity_decl_handler($this->parser, [$this, 'handleUnparsedEntitiyDeclaration']);
 	}
 
+	/**
+	 * @psalm-suppress RedundantConditionGivenDocblockType This is a workaround for an error with PHP 7.3 on
+	 *                                                      Windows and MacOs
+	 */
 	public function __destruct() {
 		// Workaround for an error with php 7.3 on Windows and MacOs
 		// remove if condition when 7.3 version not supported anymore


### PR DESCRIPTION
Fix #53. ~~Put in safe collections constructors, by making them final.~~
~~Other minor fixes.~~

~~__What does not convince me in setting the constructors `final`__~~

~~When I decide to extend a class of a library, I usually want to encapsulate some repetitive operations and setup, which I desire to avoid on each instantiation. For example, suppose I want a `Set` of Book objects and I want to be sure that the collection contains *only* Book objects:~~

```php
<?php declare(strict_types=true);

use Model\Book;
use phootwork\collection\Set;

class BookSet extends Set
{
    public function __construct($array) {
        for ($array as $object) {
            if(! $object instanceof Book) {
                throw new \InvalidArgumentException("BookSet can only contains instances of Model\Book class.");
            }
       }
       parent::__construct($array);  //this is safe anyway
    }
}
```
~~If the `Set::__constructor()` is final, then I have to manually check it on every instantiation.~~

~~What's your opinion?~~

New commit. Now I like it! :smile: 