### PR TITLE
PR #61

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         operating-system: [ubuntu-latest, windows-latest, macOS-latest]
-        php-versions: ['7.2', '7.3', '7.4']
+        php-versions: ['7.2', '7.3', '7.4', '8.0']
     runs-on: ${{ matrix.operating-system }}
     steps:
       - name: Fix autocrlf on Windows
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup PHP, with composer and extensions
-        uses: shivammathur/setup-php@v1
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: mbstring, dom, json, libxml, xml, xmlwriter
@@ -35,5 +35,7 @@ jobs:
         run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
       - name: Check code style
         run: composer cs
+        env:
+          PHP_CS_FIXER_IGNORE_ENV: 1
       - name: Test with phpunit
         run: composer test

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "phootwork/php-cs-fixer-config": "^0.2",
     "phpunit/phpunit": "^8.0",
     "mikey179/vfsstream": "^1.6",
-    "vimeo/psalm": "^3.4"
+    "psalm/phar": "^4.3"
   },
   "autoload": {
     "psr-4": {
@@ -61,7 +61,7 @@
     }
   },
   "scripts": {
-    "analytics": "psalm",
+    "analytics": "vendor/bin/psalm.phar",
     "check": [
       "@test",
       "@analytics",

--- a/tests/lang/inflector/InflectorTest.php
+++ b/tests/lang/inflector/InflectorTest.php
@@ -113,9 +113,8 @@ class InflectorTest extends TestCase {
 	 */
 	public function testWrongTypeToPluralizeThrowsException($wrong): void {
 		$this->expectException(\TypeError::class);
-		$this->expectExceptionMessage(
-			'Argument 1 passed to phootwork\lang\inflector\Inflector::getPluralForm() must be of the type string'
-		);
+		// No exception message here, because it's changed in PHP 8
+
 		$pluralizer = new Inflector();
 		$pluralizer->getPluralForm($wrong);
 	}
@@ -133,9 +132,7 @@ class InflectorTest extends TestCase {
 	 */
 	public function testWrongTypeToSingularizeThrowsException($wrong): void {
 		$this->expectException(\TypeError::class);
-		$this->expectExceptionMessage(
-			'Argument 1 passed to phootwork\lang\inflector\Inflector::getSingularForm() must be of the type string'
-		);
+		// No exception message here, because it's changed in PHP 8
 
 		$pluralizer = new Inflector();
 		$pluralizer->getSingularForm($wrong);

--- a/tests/tokenizer/TokenCollectionTest.php
+++ b/tests/tokenizer/TokenCollectionTest.php
@@ -19,7 +19,12 @@ class TokenCollectionTest extends TokenizerTest {
 		$tokenizer = new PhpTokenizer();
 		$tokens = $tokenizer->tokenize($sample);
 
-		$this->assertEquals(99, $tokens->size(), 'The fixture class has 99 tokens');
+		// the native PHP function `token_get_all` considers the string "a\b\c" as
+		// one single token in PHP 8 and 5 different tokens in PHP < 8
+		phpversion() < '8.0.0' ?
+			$this->assertEquals(99, $tokens->size(), 'The fixture class has 99 tokens') :
+			$this->assertEquals(95, $tokens->size(), 'The fixture class has 95 tokens')
+		;
 		$this->assertInstanceOf(Token::class, $tokens->get(55));
 		$this->assertNull($tokens->get(500));
 	}


### PR DESCRIPTION
Small changes required for PHP 8 compatibility:

-   remove _Psalm_ library and introduce the official `psalm.phar` archive, to avoid dependencies conflicts
-   adjust `tests\lang\inflector\InflectorTest` because some PHP exception messages are changed
-   adjust tokenizer test because `tokek_get_all` PHP function considers the string "a\b\c" as one single token in PHP 8 and 5 different tokens in PHP 7.x