### PR TITLE
Fix insert method

### DIFF
--- a/src/lang/parts/InsertPart.php
+++ b/src/lang/parts/InsertPart.php
@@ -26,7 +26,7 @@ trait InsertPart {
 		}
 
 		if (is_int($index)) {
-			array_splice($this->array, $index, 0, $element);
+			array_splice($this->array, $index, 0, [$element]);
 		}
 
 		if (is_string($index)) {

--- a/tests/lang/ArrayTest.php
+++ b/tests/lang/ArrayTest.php
@@ -592,4 +592,28 @@ class ArrayTest extends TestCase {
 		$this->assertEquals(2, $animals->size());
 		$this->assertEquals(['canid' => 'wolfe', 'reptile' => 'mamba'], $animals->toArray());
 	}
+
+	public function testInsertArrayableObject(): void {
+		$cartoons = new ArrayObject();
+		$goNagai = new ArrayObject(['Mazinger Z', 'Great Mazinger']);
+		$marvel = new ArrayObject(['X-Men', 'Spiderman', 'Devil']);
+		$dc = new ArrayObject(['Superman', 'Wonder Woman', 'Bat Man']);
+		$cartoons->add($goNagai, $marvel);
+
+		$this->assertEquals(2, $cartoons->size());
+		$this->assertEquals([$goNagai, $marvel], $cartoons->toArray());
+
+		$cartoons->insert($dc, 1);
+
+		$this->assertEquals(3, $cartoons->size());
+		$this->assertEquals([$goNagai, $dc, $marvel], $cartoons->toArray());
+	}
+
+	public function testInsertNull(): void {
+		$goNagai = new ArrayObject(['Mazinger Z', 'Great Mazinger']);
+		$goNagai->insert(null, 0);
+
+		$this->assertEquals(3, $goNagai->count());
+		$this->assertEquals([null, 'Mazinger Z', 'Great Mazinger'], $goNagai->toArray());
+	}
 }


### PR DESCRIPTION
Fix https://github.com/phootwork/phootwork/blob/10ec22d337109d458c8c82dc8b55e90bdcff03a5/src/lang/parts/InsertPart.php#L29
According to [PHP documentation](https://www.php.net/manual/en/function.array-splice.php), the fourth parameter should be an array.
I provided two tests, failing without this commit.