### PR TITLE
Add missing dependency

### DIFF
--- a/src/lang/composer.json
+++ b/src/lang/composer.json
@@ -24,7 +24,8 @@
 	},
 	"require" : {
 		"php" : ">=8.0",
-		"symfony/polyfill-mbstring" : "^1.12"
+		"symfony/polyfill-mbstring" : "^1.12",
+		"symfony/polyfill-php81": "^1.22"
 	},
 	"homepage" : "https://phootwork.github.io/lang/"
 }


### PR DESCRIPTION
Without this dependency, `lang` and `collection` packages don't work when installed as standalone libraries.