### PR TITLE
Fix static create methods

### DIFF
--- a/src/file/FileOperationTrait.php
+++ b/src/file/FileOperationTrait.php
@@ -25,10 +25,12 @@ trait FileOperationTrait {
 	 *
 	 * @param string|Stringable $pathname
 	 *
-	 * @return self
+	 * @return static
+	 *
+	 * @psalm-suppress UnsafeInstantiation
 	 */
-	public static function create(string|Stringable $pathname): self {
-		return new self($pathname);
+	public static function create(string|Stringable $pathname): static {
+		return new static($pathname);
 	}
 
 	/**

--- a/src/lang/Text.php
+++ b/src/lang/Text.php
@@ -59,13 +59,13 @@ class Text implements Comparable, Stringable {
 	 * @param string|Stringable       $string
 	 * @param string|null $encoding
 	 *
-	 * @return Text
+	 * @return static
 	 *
 	 * @see Text::__construct()
-	 *
+	 * @psalm-suppress UnsafeInstantiation
 	 */
-	public static function create(string|Stringable $string, ?string $encoding = null) {
-		return new self($string, $encoding);
+	public static function create(string|Stringable $string, ?string $encoding = null): static {
+		return new static($string, $encoding);
 	}
 
 	/**

--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -218,4 +218,14 @@ class FileTest extends FilesystemTest {
 
 		$file->write('Some content.');
 	}
+
+	public function testCreate(): void {
+		$file = File::create('a_file.txt');
+		$fileExt = FileExtension::create('myfile.txt');
+		$this->assertInstanceOf(File::class, $file);
+		$this->assertInstanceOf(FileExtension::class, $fileExt);
+	}
+}
+
+class FileExtension extends File {
 }

--- a/tests/lang/TextTest.php
+++ b/tests/lang/TextTest.php
@@ -820,4 +820,15 @@ id est laborum.';
 		$text = new Text('Let it go');
 		$text->split('');
 	}
+
+	public function testCreate(): void {
+		$text = Text::create('A string');
+		$textExt = TextExtension::create('Another string');
+
+		$this->assertInstanceOf(Text::class, $text);
+		$this->assertInstanceOf(TextExtension::class, $textExt);
+	}
+}
+
+class TextExtension extends Text {
 }


### PR DESCRIPTION
Fix `phootwork\lang\Text:create()` and `phootwork\file\FileOprationTrait::create()`
to return the correct class, when extend them.

Example:
```php
<?php
use phootwork\file\File;

class FileExtension extends File {}

$fileExt = FileExtension::create('a_file.txt');

var_dump($fileExt instanceof FileExtension::class); 
// false without this commit
//since `create` method returns a `phootwork\file\File` instance
```