### PR TITLE
Add getSize() method

### DIFF
--- a/src/file/File.php
+++ b/src/file/File.php
@@ -100,6 +100,28 @@ class File implements Stringable {
 	}
 
 	/**
+	 * Get the size of the file in bytes.
+	 *
+	 * @throws FileException If the file does not exist or it's not accessible
+	 */
+	public function getSize(): int {
+		$size = @filesize($this->getPathname()->toString());
+
+		if ($size === false) {
+			$message = Text::create(error_get_last()['message'] ?? '')
+				->replace('filesize(): ', '')
+				->prepend('Impossible to get the file size: ')
+				->trim(' :')
+				->ensureEnd('.')
+			;
+
+			throw new FileException((string) $message);
+		}
+
+		return $size;
+	}
+
+	/**
 	 * String representation of this file as pathname
 	 */
 	public function __toString(): string {

--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -9,6 +9,7 @@
  */
 namespace phootwork\file\tests;
 
+use org\bovigo\vfs\content\LargeFileContent;
 use org\bovigo\vfs\vfsStream;
 use phootwork\file\Directory;
 use phootwork\file\exception\FileException;
@@ -217,6 +218,22 @@ class FileTest extends FilesystemTest {
 		$file = new File($stream->url());
 
 		$file->write('Some content.');
+	}
+
+	public function testGetSize(): void {
+		$stream = vfsStream::newFile('myfile.txt')
+			->withContent(LargeFileContent::withKilobytes(1))
+			->at($this->root);
+		$file = new File($stream->url());
+
+		$this->assertEquals(1024, $file->getSize());
+	}
+
+	public function testGetSizeWithNonExistentFileThrowsException(): void {
+		$this->expectException(FileException::class);
+		$this->expectExceptionMessage('Impossible to get the file size: stat failed for not_existent.txt.');
+
+		File::create('not_existent.txt')->getSize();
 	}
 
 	public function testCreate(): void {


### PR DESCRIPTION
Add `getSize()` method to `phootwork\file\File`class.

The method returns the file size in bytes and throws an exception if errors occur.
See https://www.php.net/manual/en/function.filesize

This commit close #70 . 