### PR TITLE
Normalize the pathname in Linux style

### DIFF
--- a/src/file/Directory.php
+++ b/src/file/Directory.php
@@ -24,7 +24,7 @@ class Directory implements Iterator, Stringable {
 	private ?DirectoryIterator $iterator = null;
 
 	public function __construct(string|Stringable $filename) {
-		$this->pathname = (string) $filename;
+		$this->pathname = $this->normalizePathName($filename);
 	}
 
 	/**

--- a/src/file/File.php
+++ b/src/file/File.php
@@ -21,7 +21,7 @@ class File implements Stringable {
 	use FileOperationTrait;
 
 	public function __construct(string|Stringable $filename) {
-		$this->pathname = (string) $filename;
+		$this->pathname = $this->normalizePathName($filename);
 	}
 
 	/**

--- a/src/file/FileDescriptor.php
+++ b/src/file/FileDescriptor.php
@@ -19,7 +19,7 @@ class FileDescriptor implements Stringable {
 	use FileOperationTrait;
 
 	public function __construct(string|Stringable $filename) {
-		$this->pathname = (string) $filename;
+		$this->pathname = $this->normalizePathName($filename);
 	}
 
 	/**

--- a/src/file/FileOperationTrait.php
+++ b/src/file/FileOperationTrait.php
@@ -367,4 +367,16 @@ trait FileOperationTrait {
 			throw new FileException(sprintf('Failed to create symbolic link from %s to %s', $this->pathname, (string) $targetDir));
 		}
 	}
+
+	/**
+	 * Convert Windows paths to normalized Linux paths.
+	 * Example: \my_directory\my_file.txt becomes /my_directory/my_file.txt
+	 *
+	 * @param Stringable|string $pathName
+	 *
+	 * @return string
+	 */
+	protected function normalizePathName(Stringable|string $pathName): string {
+		return str_replace('\\', '/', (string) $pathName);
+	}
 }

--- a/src/file/Path.php
+++ b/src/file/Path.php
@@ -40,6 +40,7 @@ class Path implements Stringable {
 	 */
 	public function __construct(Stringable|string $pathname) {
 		$this->pathname = new Text($pathname);
+		$this->pathname->replace('\\', '/');
 
 		if ($this->pathname->match('/^[a-zA-Z]+:\/\//')) {
 			$this->stream = $this->pathname->slice(0, (int) $this->pathname->indexOf('://') + 3)->toString();

--- a/tests/file/DirectoryTest.php
+++ b/tests/file/DirectoryTest.php
@@ -88,4 +88,10 @@ class DirectoryTest extends FilesystemTest {
 		//see https://github.com/bovigo/vfsStream/issues/119
 		$this->assertEquals(0, $dir->getInode());
 	}
+
+	public function testNormalizePath(): void {
+		$dir = new Directory('\\Documents\\MyDir');
+
+		$this->assertEquals('/Documents/MyDir', $dir->getPathname()->toString());
+	}
 }

--- a/tests/file/FileDescriptorTest.php
+++ b/tests/file/FileDescriptorTest.php
@@ -41,4 +41,10 @@ class FileDescriptorTest extends FilesystemTest {
 		$desc = new FileDescriptor($this->root->url() . '/dir/composer.json');
 		$this->assertEquals($this->root->url() . '/dir/composer.json', '' . $desc);
 	}
+
+	public function testNormalizePath(): void {
+		$fileDesc = new FileDescriptor('\\Documents\\letter.txt');
+
+		$this->assertEquals('/Documents/letter.txt', $fileDesc->getPathname()->toString());
+	}
 }

--- a/tests/file/FileTest.php
+++ b/tests/file/FileTest.php
@@ -260,6 +260,12 @@ class FileTest extends FilesystemTest {
 		File::create($stream->url())->append('Some content to append.');
 	}
 
+	public function testNormalizePath(): void {
+		$file = new File('\\Documents\\letter.txt');
+
+		$this->assertEquals('/Documents/letter.txt', $file->getPathname()->toString());
+	}
+
 	public function testCreate(): void {
 		$file = File::create('a_file.txt');
 		$fileExt = FileExtension::create('myfile.txt');


### PR DESCRIPTION
With this commit, Windows style paths, with `\` separator, are converted in Linux style, with `/` separator.
Linux notation, in fact, works under Windows, too.

This commit closes #72 

After merging it, I'll add a note in the documentation.